### PR TITLE
Dependency update (#97)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -79,7 +79,7 @@ jobs:
           username: ${{ secrets.MELINDA_QUAY_IO_USERNAME }}
           password: ${{ secrets.MELINDA_QUAY_IO_PASSWORD }}
       - name: Build and publish image to Quay.io
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.0.5",
+	"version": "3.0.6-alpha.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.0.5",
+			"version": "3.0.6-alpha.1",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.20.13",
@@ -3082,9 +3082,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
-			"integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+			"integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.11"
 			},
@@ -3394,22 +3394,22 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "12.0.7",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-12.0.7.tgz",
-			"integrity": "sha512-A5ufMv/W60NBCcwpkLjMr7takjg19RpMTQ0qfSbvhvWQH+IqgbzmDM8qy3UAU1b5q5NJaTw0HKJ5inIUdOX7Rg==",
+			"version": "12.0.9",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-12.0.9.tgz",
+			"integrity": "sha512-PHrYz7bOIuzUBwjmgoYkqLK3+nPMaO4TLT8+rTlBKs1P29Uv/k4EWOkOZKTrlYS2xXbGoofbsspWq3+zepjxqg==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-serializers": "^9.0.2",
-				"@natlibfi/sru-client": "^5.0.3",
+				"@natlibfi/marc-record-serializers": "^9.0.4",
+				"@natlibfi/sru-client": "^5.0.4",
 				"debug": "^4.3.4",
-				"deep-eql": "^4.1.1",
-				"http-status": "^1.5.3",
+				"deep-eql": "^4.1.3",
+				"http-status": "^1.6.2",
 				"moment": "^2.29.4",
-				"nock": "^13.2.9",
-				"node-fetch": "^2.6.7"
+				"nock": "^13.3.0",
+				"node-fetch": "^2.6.8"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
@@ -3965,12 +3965,12 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
 			"dependencies": {
 				"bytes": "3.1.2",
-				"content-type": "~1.0.4",
+				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"destroy": "1.2.0",
@@ -3978,7 +3978,7 @@
 				"iconv-lite": "0.4.24",
 				"on-finished": "2.4.1",
 				"qs": "6.11.0",
-				"raw-body": "2.5.1",
+				"raw-body": "2.5.2",
 				"type-is": "~1.6.18",
 				"unpipe": "1.0.0"
 			},
@@ -4315,9 +4315,9 @@
 			]
 		},
 		"node_modules/content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5105,6 +5105,29 @@
 				"winston": ">=3.x <4"
 			}
 		},
+		"node_modules/express/node_modules/body-parser": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+			"dependencies": {
+				"bytes": "3.1.2",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"on-finished": "2.4.1",
+				"qs": "6.11.0",
+				"raw-body": "2.5.1",
+				"type-is": "~1.6.18",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
 		"node_modules/express/node_modules/debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5117,6 +5140,20 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+		},
+		"node_modules/express/node_modules/raw-body": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"dependencies": {
+				"bytes": "3.1.2",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/express/node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -7000,9 +7037,9 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
 			"dependencies": {
 				"bytes": "3.1.2",
 				"http-errors": "2.0.0",
@@ -10726,9 +10763,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
-			"integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+			"integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.11"
 			}
@@ -10959,19 +10996,19 @@
 			}
 		},
 		"@natlibfi/melinda-commons": {
-			"version": "12.0.7",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-12.0.7.tgz",
-			"integrity": "sha512-A5ufMv/W60NBCcwpkLjMr7takjg19RpMTQ0qfSbvhvWQH+IqgbzmDM8qy3UAU1b5q5NJaTw0HKJ5inIUdOX7Rg==",
+			"version": "12.0.9",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-12.0.9.tgz",
+			"integrity": "sha512-PHrYz7bOIuzUBwjmgoYkqLK3+nPMaO4TLT8+rTlBKs1P29Uv/k4EWOkOZKTrlYS2xXbGoofbsspWq3+zepjxqg==",
 			"requires": {
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-serializers": "^9.0.2",
-				"@natlibfi/sru-client": "^5.0.3",
+				"@natlibfi/marc-record-serializers": "^9.0.4",
+				"@natlibfi/sru-client": "^5.0.4",
 				"debug": "^4.3.4",
-				"deep-eql": "^4.1.1",
-				"http-status": "^1.5.3",
+				"deep-eql": "^4.1.3",
+				"http-status": "^1.6.2",
 				"moment": "^2.29.4",
-				"nock": "^13.2.9",
-				"node-fetch": "^2.6.7"
+				"nock": "^13.3.0",
+				"node-fetch": "^2.6.8"
 			}
 		},
 		"@natlibfi/melinda-rest-api-commons": {
@@ -11377,12 +11414,12 @@
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
 		},
 		"body-parser": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
 			"requires": {
 				"bytes": "3.1.2",
-				"content-type": "~1.0.4",
+				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"destroy": "1.2.0",
@@ -11390,7 +11427,7 @@
 				"iconv-lite": "0.4.24",
 				"on-finished": "2.4.1",
 				"qs": "6.11.0",
-				"raw-body": "2.5.1",
+				"raw-body": "2.5.2",
 				"type-is": "~1.6.18",
 				"unpipe": "1.0.0"
 			},
@@ -11626,9 +11663,9 @@
 			}
 		},
 		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
 		},
 		"convert-source-map": {
 			"version": "1.9.0",
@@ -12191,6 +12228,25 @@
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
+				"body-parser": {
+					"version": "1.20.1",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+					"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+					"requires": {
+						"bytes": "3.1.2",
+						"content-type": "~1.0.4",
+						"debug": "2.6.9",
+						"depd": "2.0.0",
+						"destroy": "1.2.0",
+						"http-errors": "2.0.0",
+						"iconv-lite": "0.4.24",
+						"on-finished": "2.4.1",
+						"qs": "6.11.0",
+						"raw-body": "2.5.1",
+						"type-is": "~1.6.18",
+						"unpipe": "1.0.0"
+					}
+				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -12203,6 +12259,17 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+				},
+				"raw-body": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+					"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+					"requires": {
+						"bytes": "3.1.2",
+						"http-errors": "2.0.0",
+						"iconv-lite": "0.4.24",
+						"unpipe": "1.0.0"
+					}
 				},
 				"safe-buffer": {
 					"version": "5.2.1",
@@ -13556,9 +13623,9 @@
 			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
 		},
 		"raw-body": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
 			"requires": {
 				"bytes": "3.1.2",
 				"http-errors": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.0.6-alpha.1",
+	"version": "3.0.6-alpha.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.0.6-alpha.1",
+			"version": "3.0.6-alpha.2",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.20.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8220,9 +8220,9 @@
 			"dev": true
 		},
 		"node_modules/xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -14496,9 +14496,9 @@
 			"dev": true
 		},
 		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
 			"requires": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.0.5",
+	"version": "3.0.6-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.0.6-alpha.1",
+	"version": "3.0.6-alpha.2",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
* Bump body-parser from 1.20.1 to 1.20.2 (#96)
* Bump @babel/runtime from 7.20.13 to 7.21.0 (#95)
* Bump docker/build-push-action from 3 to 4 (#94)
* Bump @natlibfi/melinda-commons from 12.0.7 to 12.0.9 (#93)

* 3.0.6-alpha.1