### PR TITLE
Features require auth for read & default accept value for prio read

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.0.6",
+	"version": "3.0.7-alpha.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.0.6",
+			"version": "3.0.7-alpha.1",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,33 +9,33 @@
 			"version": "3.0.6",
 			"license": "AGPL-3.0+",
 			"dependencies": {
-				"@babel/runtime": "^7.20.13",
-				"@natlibfi/marc-record-serializers": "^9.0.4",
+				"@babel/runtime": "^7.21.0",
+				"@natlibfi/marc-record-serializers": "^10.0.4",
 				"@natlibfi/melinda-backend-commons": "^2.1.0",
-				"@natlibfi/melinda-commons": "^12.0.7",
-				"@natlibfi/melinda-rest-api-commons": "^3.0.6",
+				"@natlibfi/melinda-commons": "^13.0.4",
+				"@natlibfi/melinda-rest-api-commons": "^4.0.4",
 				"@natlibfi/passport-melinda-aleph": "^2.0.4",
-				"@natlibfi/sru-client": "^5.0.4",
-				"body-parser": "^1.20.1",
+				"@natlibfi/sru-client": "^6.0.2",
+				"body-parser": "^1.20.2",
 				"express": "^4.18.2",
 				"http-status": "^1.6.2",
 				"moment": "^2.29.4",
 				"mongo-sanitize": "^1.1.0",
-				"nodemon": "^2.0.20",
+				"nodemon": "^2.0.22",
 				"passport": "^0.6.0",
 				"passport-http": "^0.3.0",
 				"uuid": "^9.0.0"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.20.7",
-				"@babel/core": "^7.20.12",
-				"@babel/eslint-parser": "^7.19.1",
+				"@babel/cli": "^7.21.0",
+				"@babel/core": "^7.21.4",
+				"@babel/eslint-parser": "^7.21.3",
 				"@babel/node": "^7.20.7",
-				"@babel/preset-env": "^7.20.2",
-				"@babel/register": "^7.18.9",
-				"@natlibfi/eslint-config-melinda-backend": "^2.0.2",
+				"@babel/preset-env": "^7.21.4",
+				"@babel/register": "^7.21.0",
+				"@natlibfi/eslint-config-melinda-backend": "^3.0.0",
 				"cross-env": "^7.0.3",
-				"eslint": "^8.32.0"
+				"eslint": "^8.38.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -1487,12 +1487,12 @@
 			"optional": true
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.20.7.tgz",
-			"integrity": "sha512-WylgcELHB66WwQqItxNILsMlaTd8/SO6SgTTjMp4uCI7P4QyH1r3nqgFmO3BfM4AtfniHgFMH3EpYFj/zynBkQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.21.0.tgz",
+			"integrity": "sha512-xi7CxyS8XjSyiwUGCfwf+brtJxjW1/ZTcBUkP10xawIEXLX5HzLn+3aXkgxozcP2UhRhtKTmQurw9Uaes7jZrA==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.8",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"commander": "^4.0.1",
 				"convert-source-map": "^1.1.0",
 				"fs-readdir-recursive": "^1.1.0",
@@ -1516,9 +1516,9 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+			"integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
 			"dependencies": {
 				"@babel/highlight": "^7.18.6"
 			},
@@ -1527,28 +1527,28 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.20.10",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-			"integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.4.tgz",
+			"integrity": "sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
-			"integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.4.tgz",
+			"integrity": "sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==",
 			"dependencies": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-compilation-targets": "^7.20.7",
-				"@babel/helper-module-transforms": "^7.20.11",
-				"@babel/helpers": "^7.20.7",
-				"@babel/parser": "^7.20.7",
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.21.4",
+				"@babel/generator": "^7.21.4",
+				"@babel/helper-compilation-targets": "^7.21.4",
+				"@babel/helper-module-transforms": "^7.21.2",
+				"@babel/helpers": "^7.21.0",
+				"@babel/parser": "^7.21.4",
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.12",
-				"@babel/types": "^7.20.7",
+				"@babel/traverse": "^7.21.4",
+				"@babel/types": "^7.21.4",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -1564,9 +1564,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
-			"integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
+			"version": "7.21.3",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz",
+			"integrity": "sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==",
 			"dev": true,
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -1582,12 +1582,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-			"integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
+			"integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
 			"dependencies": {
-				"@babel/types": "^7.20.7",
+				"@babel/types": "^7.21.4",
 				"@jridgewell/gen-mapping": "^0.3.2",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
 			},
 			"engines": {
@@ -1633,12 +1634,12 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
-			"integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.4.tgz",
+			"integrity": "sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==",
 			"dependencies": {
-				"@babel/compat-data": "^7.20.5",
-				"@babel/helper-validator-option": "^7.18.6",
+				"@babel/compat-data": "^7.21.4",
+				"@babel/helper-validator-option": "^7.21.0",
 				"browserslist": "^4.21.3",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.0"
@@ -1651,15 +1652,15 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
-			"integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.4.tgz",
+			"integrity": "sha512-46QrX2CQlaFRF4TkwfTt6nJD7IHq8539cCL7SDpqWSDeJKY1xylKKY5F/33mJhLZ3mFvKv2gGrVS6NkyF6qs+Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-member-expression-to-functions": "^7.20.7",
+				"@babel/helper-function-name": "^7.21.0",
+				"@babel/helper-member-expression-to-functions": "^7.21.0",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
 				"@babel/helper-replace-supers": "^7.20.7",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
@@ -1726,12 +1727,12 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.19.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
 			"dependencies": {
-				"@babel/template": "^7.18.10",
-				"@babel/types": "^7.19.0"
+				"@babel/template": "^7.20.7",
+				"@babel/types": "^7.21.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1749,12 +1750,12 @@
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
-			"integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.21.0.tgz",
+			"integrity": "sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.20.7"
+				"@babel/types": "^7.21.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1772,9 +1773,9 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
-			"integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
+			"version": "7.21.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+			"integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-module-imports": "^7.18.6",
@@ -1782,8 +1783,8 @@
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"@babel/helper-validator-identifier": "^7.19.1",
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.10",
-				"@babel/types": "^7.20.7"
+				"@babel/traverse": "^7.21.2",
+				"@babel/types": "^7.21.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1896,9 +1897,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+			"integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1919,13 +1920,13 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
-			"integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
+			"integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
 			"dependencies": {
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.13",
-				"@babel/types": "^7.20.7"
+				"@babel/traverse": "^7.21.0",
+				"@babel/types": "^7.21.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1968,9 +1969,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-			"integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
+			"integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -2045,12 +2046,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-class-static-block": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.20.7.tgz",
-			"integrity": "sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.21.0.tgz",
+			"integrity": "sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.20.7",
+				"@babel/helper-create-class-features-plugin": "^7.21.0",
 				"@babel/helper-plugin-utils": "^7.20.2",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			},
@@ -2193,9 +2194,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-optional-chaining": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.20.7.tgz",
-			"integrity": "sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz",
+			"integrity": "sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.20.2",
@@ -2226,13 +2227,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-private-property-in-object": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.20.5.tgz",
-			"integrity": "sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0.tgz",
+			"integrity": "sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
-				"@babel/helper-create-class-features-plugin": "^7.20.5",
+				"@babel/helper-create-class-features-plugin": "^7.21.0",
 				"@babel/helper-plugin-utils": "^7.20.2",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
 			},
@@ -2499,9 +2500,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.11.tgz",
-			"integrity": "sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.21.0.tgz",
+			"integrity": "sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.20.2"
@@ -2514,15 +2515,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.7.tgz",
-			"integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.21.0.tgz",
+			"integrity": "sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-compilation-targets": "^7.20.7",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
+				"@babel/helper-function-name": "^7.21.0",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
 				"@babel/helper-plugin-utils": "^7.20.2",
 				"@babel/helper-replace-supers": "^7.20.7",
@@ -2553,9 +2554,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.7.tgz",
-			"integrity": "sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==",
+			"version": "7.21.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.21.3.tgz",
+			"integrity": "sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.20.2"
@@ -2615,12 +2616,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz",
-			"integrity": "sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.21.0.tgz",
+			"integrity": "sha512-LlUYlydgDkKpIY7mcBWvyPPmMcOphEyYA27Ef4xpbh1IiDNLr0kZsos2nf92vz3IccvJI25QUwp86Eo5s6HmBQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.20.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2693,12 +2694,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
-			"integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
+			"version": "7.21.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.2.tgz",
+			"integrity": "sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.20.11",
+				"@babel/helper-module-transforms": "^7.21.2",
 				"@babel/helper-plugin-utils": "^7.20.2",
 				"@babel/helper-simple-access": "^7.20.2"
 			},
@@ -2791,9 +2792,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.7.tgz",
-			"integrity": "sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==",
+			"version": "7.21.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.21.3.tgz",
+			"integrity": "sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.20.2"
@@ -2959,31 +2960,31 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
-			"integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.21.4.tgz",
+			"integrity": "sha512-2W57zHs2yDLm6GD5ZpvNn71lZ0B/iypSdIeq25OurDKji6AdzV07qp4s3n1/x5BqtiGaTrPN3nerlSCaC5qNTw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.20.1",
-				"@babel/helper-compilation-targets": "^7.20.0",
+				"@babel/compat-data": "^7.21.4",
+				"@babel/helper-compilation-targets": "^7.21.4",
 				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/helper-validator-option": "^7.18.6",
+				"@babel/helper-validator-option": "^7.21.0",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
-				"@babel/plugin-proposal-async-generator-functions": "^7.20.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.20.7",
+				"@babel/plugin-proposal-async-generator-functions": "^7.20.7",
 				"@babel/plugin-proposal-class-properties": "^7.18.6",
-				"@babel/plugin-proposal-class-static-block": "^7.18.6",
+				"@babel/plugin-proposal-class-static-block": "^7.21.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.18.6",
 				"@babel/plugin-proposal-export-namespace-from": "^7.18.9",
 				"@babel/plugin-proposal-json-strings": "^7.18.6",
-				"@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.20.7",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
 				"@babel/plugin-proposal-numeric-separator": "^7.18.6",
-				"@babel/plugin-proposal-object-rest-spread": "^7.20.2",
+				"@babel/plugin-proposal-object-rest-spread": "^7.20.7",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
-				"@babel/plugin-proposal-optional-chaining": "^7.18.9",
+				"@babel/plugin-proposal-optional-chaining": "^7.21.0",
 				"@babel/plugin-proposal-private-methods": "^7.18.6",
-				"@babel/plugin-proposal-private-property-in-object": "^7.18.6",
+				"@babel/plugin-proposal-private-property-in-object": "^7.21.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.18.6",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -3000,40 +3001,40 @@
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
-				"@babel/plugin-transform-arrow-functions": "^7.18.6",
-				"@babel/plugin-transform-async-to-generator": "^7.18.6",
+				"@babel/plugin-transform-arrow-functions": "^7.20.7",
+				"@babel/plugin-transform-async-to-generator": "^7.20.7",
 				"@babel/plugin-transform-block-scoped-functions": "^7.18.6",
-				"@babel/plugin-transform-block-scoping": "^7.20.2",
-				"@babel/plugin-transform-classes": "^7.20.2",
-				"@babel/plugin-transform-computed-properties": "^7.18.9",
-				"@babel/plugin-transform-destructuring": "^7.20.2",
+				"@babel/plugin-transform-block-scoping": "^7.21.0",
+				"@babel/plugin-transform-classes": "^7.21.0",
+				"@babel/plugin-transform-computed-properties": "^7.20.7",
+				"@babel/plugin-transform-destructuring": "^7.21.3",
 				"@babel/plugin-transform-dotall-regex": "^7.18.6",
 				"@babel/plugin-transform-duplicate-keys": "^7.18.9",
 				"@babel/plugin-transform-exponentiation-operator": "^7.18.6",
-				"@babel/plugin-transform-for-of": "^7.18.8",
+				"@babel/plugin-transform-for-of": "^7.21.0",
 				"@babel/plugin-transform-function-name": "^7.18.9",
 				"@babel/plugin-transform-literals": "^7.18.9",
 				"@babel/plugin-transform-member-expression-literals": "^7.18.6",
-				"@babel/plugin-transform-modules-amd": "^7.19.6",
-				"@babel/plugin-transform-modules-commonjs": "^7.19.6",
-				"@babel/plugin-transform-modules-systemjs": "^7.19.6",
+				"@babel/plugin-transform-modules-amd": "^7.20.11",
+				"@babel/plugin-transform-modules-commonjs": "^7.21.2",
+				"@babel/plugin-transform-modules-systemjs": "^7.20.11",
 				"@babel/plugin-transform-modules-umd": "^7.18.6",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.20.5",
 				"@babel/plugin-transform-new-target": "^7.18.6",
 				"@babel/plugin-transform-object-super": "^7.18.6",
-				"@babel/plugin-transform-parameters": "^7.20.1",
+				"@babel/plugin-transform-parameters": "^7.21.3",
 				"@babel/plugin-transform-property-literals": "^7.18.6",
-				"@babel/plugin-transform-regenerator": "^7.18.6",
+				"@babel/plugin-transform-regenerator": "^7.20.5",
 				"@babel/plugin-transform-reserved-words": "^7.18.6",
 				"@babel/plugin-transform-shorthand-properties": "^7.18.6",
-				"@babel/plugin-transform-spread": "^7.19.0",
+				"@babel/plugin-transform-spread": "^7.20.7",
 				"@babel/plugin-transform-sticky-regex": "^7.18.6",
 				"@babel/plugin-transform-template-literals": "^7.18.9",
 				"@babel/plugin-transform-typeof-symbol": "^7.18.9",
 				"@babel/plugin-transform-unicode-escapes": "^7.18.10",
 				"@babel/plugin-transform-unicode-regex": "^7.18.6",
 				"@babel/preset-modules": "^0.1.5",
-				"@babel/types": "^7.20.2",
+				"@babel/types": "^7.21.4",
 				"babel-plugin-polyfill-corejs2": "^0.3.3",
 				"babel-plugin-polyfill-corejs3": "^0.6.0",
 				"babel-plugin-polyfill-regenerator": "^0.4.1",
@@ -3064,9 +3065,9 @@
 			}
 		},
 		"node_modules/@babel/register": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.18.9.tgz",
-			"integrity": "sha512-ZlbnXDcNYHMR25ITwwNKT88JiaukkdVj/nG7r3wnuXkOTHc60Uy05PwMCPre0hSkY68E6zK3xz+vUJSP2jWmcw==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.21.0.tgz",
+			"integrity": "sha512-9nKsPmYDi5DidAqJaQooxIhsLJiNMkGr8ypQ8Uic7cIox7UCDsM7HuUGxdGT7mSDTYbqzIdsOWzfBton/YJrMw==",
 			"dependencies": {
 				"clone-deep": "^4.0.1",
 				"find-cache-dir": "^2.0.0",
@@ -3106,18 +3107,18 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
-			"integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
+			"integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
+				"@babel/code-frame": "^7.21.4",
+				"@babel/generator": "^7.21.4",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
+				"@babel/helper-function-name": "^7.21.0",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.20.13",
-				"@babel/types": "^7.20.7",
+				"@babel/parser": "^7.21.4",
+				"@babel/types": "^7.21.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -3126,9 +3127,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
-			"integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
+			"integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.19.4",
 				"@babel/helper-validator-identifier": "^7.19.1",
@@ -3156,15 +3157,51 @@
 				"kuler": "^2.0.0"
 			}
 		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+			"integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+			"integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+			"integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
+				"espree": "^9.5.1",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -3180,9 +3217,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "13.19.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-			"integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+			"version": "13.20.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -3192,6 +3229,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
+			"integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -3270,27 +3316,21 @@
 			}
 		},
 		"node_modules/@natlibfi/eslint-config-melinda-backend": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-2.0.2.tgz",
-			"integrity": "sha512-eQlj3IkrOdwti8DcuXMg+GxbL9GC919qQUsvieeL/WS3peDbAGF9R3NtdkyJkZdidtrFSd5pc1zuQos3oxToMA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.0.tgz",
+			"integrity": "sha512-Nn/jPwvwSY44xczjDiU0eR4t3Awbfc/nYrromiSn6Atx7h6V87rcXrAr1E1QtXKDWg/+7b36zNdBxO5mkaBliA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/eslint-parser": "^7.18.9",
-				"eslint-plugin-functional": "^4.2.2"
+				"@babel/eslint-parser": "^7.21.3",
+				"@typescript-eslint/type-utils": "^5.58.0",
+				"@typescript-eslint/utils": "^5.58.0",
+				"eslint-plugin-functional": "^5.0.7"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=16"
 			},
 			"peerDependencies": {
-				"eslint": "^8.23.0"
-			}
-		},
-		"node_modules/@natlibfi/fixugen": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-1.1.0.tgz",
-			"integrity": "sha512-sZoOkCRAWU0JtVAG4pujjeGkcihqErk4+u6OFcA8AMFT1UiEXl68wJNmV6URYDGAMtVjcP2cY6QwINnmnSU2RA==",
-			"engines": {
-				"node": ">=14"
+				"eslint": "^8.38.0"
 			}
 		},
 		"node_modules/@natlibfi/issn-verify": {
@@ -3311,57 +3351,57 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-9.0.4.tgz",
-			"integrity": "sha512-17w/VL5rZ9NOZiggrlLaYhg8WcuFYuqZU9i0lWqRp9Ed9n8vQ/ihoHJoQeAq03g+1F6yylQp5wXNZ/49RLVwtQ==",
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.0.4.tgz",
+			"integrity": "sha512-6qSubMuBNwcN3vskwnCjA1b52NzOdmil6Zcabq+S7a77IRZ/p2b6WlAOPGZvoBSqA1vNY7sYr2Ol/X6m3bgxog==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^7.2.2",
-				"@xmldom/xmldom": "^0.8.6",
+				"@xmldom/xmldom": "^0.8.7",
 				"stream-json": "^1.7.5",
-				"xml2js": ">=0.4.23 <1.0.0",
-				"yargs": "^17.6.2"
+				"xml2js": ">=0.5.0 <1.0.0",
+				"yargs": "^17.7.1"
 			},
 			"bin": {
 				"marc-record-serializers": "dist/cli.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validate": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-7.0.3.tgz",
-			"integrity": "sha512-NLTnH8MTlIXvoxC7dJ2eOKZeJ+pBNiiTMIn6q4giFtxqAWhTxAqQgwm1PQgsVDeYl6Tmp6+9jPMtTpXwMe8oWA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-8.0.0.tgz",
+			"integrity": "sha512-jhj3Vll+5wHdl8DVINgRcjZSGc2N9ZM7tOGq9opfWYerARasciA1Ds/Qe45/NP3KJflN16bwk3o7oJ4FTTnYdg==",
 			"dependencies": {
-				"@babel/runtime": "^7.19.0",
-				"@natlibfi/marc-record": "^7.2.1"
+				"@babel/runtime": "^7.20.13",
+				"@natlibfi/marc-record": "^7.2.2"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-9.1.1.tgz",
-			"integrity": "sha512-Z1njdjkDYDbxqZ+romxzqKAjIC6cv8NPlntIpexU517sDljoRnGvJsUybTVG/wd9rWoU0nvAdS+17Q8lH+iycA==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.3.2.tgz",
+			"integrity": "sha512-zOvGti2AK33snhFDYuSKCKvcgsBX2xzZZ97morxA9WdjKWgTErBoPo3WmOX3zhLT8Ac5Rdyd4/uNGiolG0XLqw==",
 			"dependencies": {
-				"@babel/register": "^7.18.9",
+				"@babel/register": "^7.21.0",
 				"@natlibfi/issn-verify": "^1.0.0",
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-validate": "^7.0.2",
+				"@natlibfi/marc-record-validate": "^8.0.0",
 				"cld3-asm": "^3.1.1",
 				"clone": "^2.1.2",
 				"debug": "^4.3.4",
-				"isbn3": "^1.1.28",
+				"isbn3": "^1.1.35",
 				"langs": "^2.0.0",
-				"node-fetch": "^2.6.7",
-				"xml2js": ">=0.4.23 <1.0.0"
+				"node-fetch": "^2.6.9",
+				"xml2js": ">=0.5.0 <1.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@natlibfi/marc-record-validate": "^7.0.2"
+				"@natlibfi/marc-record-validate": "^8.0.0"
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
@@ -3394,13 +3434,13 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "12.0.9",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-12.0.9.tgz",
-			"integrity": "sha512-PHrYz7bOIuzUBwjmgoYkqLK3+nPMaO4TLT8+rTlBKs1P29Uv/k4EWOkOZKTrlYS2xXbGoofbsspWq3+zepjxqg==",
+			"version": "13.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.4.tgz",
+			"integrity": "sha512-xcNHbNFbG4fPFRQroQmXyhoHMGD2Ath/CslePzDGLpYDTxHS/vPcPIXfSNFQQXfhcBOBDKF1Z4OKuJMRaNhg2w==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-serializers": "^9.0.4",
-				"@natlibfi/sru-client": "^5.0.4",
+				"@natlibfi/marc-record-serializers": "^10.0.4",
+				"@natlibfi/sru-client": "^6.0.2",
 				"debug": "^4.3.4",
 				"deep-eql": "^4.1.3",
 				"http-status": "^1.6.2",
@@ -3413,17 +3453,16 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-3.0.6.tgz",
-			"integrity": "sha512-yMtOnh2cSVXu1pDsmYOcY94SuYFHs/A5fdgoAC5Bm1H40kvBlqLLAxE1kSr/huVSiYAfe0Aqhn/41YpZnNaDpw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.0.4.tgz",
+			"integrity": "sha512-K4cA2O6lKXERi7xZ08r9QQBFkhEwe8eiIAE0Sv11HF3u4+MEKEPEepe/AyQILQBBgZBWu4GPe7k5HkGImIVrOQ==",
 			"dependencies": {
-				"@natlibfi/fixugen": "^1.1.0",
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-serializers": "^9.0.4",
-				"@natlibfi/marc-record-validate": "^7.0.3",
-				"@natlibfi/marc-record-validators-melinda": "^9.1.1",
+				"@natlibfi/marc-record-serializers": "^10.0.4",
+				"@natlibfi/marc-record-validate": "^8.0.0",
+				"@natlibfi/marc-record-validators-melinda": "^10.3.2",
 				"@natlibfi/melinda-backend-commons": "^2.1.0",
-				"@natlibfi/melinda-commons": "^12.0.7",
+				"@natlibfi/melinda-commons": "^13.0.4",
 				"amqplib": ">=0.10.3 <1.0.0",
 				"debug": "^4.3.4",
 				"http-status": "^1.6.2",
@@ -3451,7 +3490,44 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@natlibfi/sru-client": {
+		"node_modules/@natlibfi/passport-melinda-aleph/node_modules/@natlibfi/marc-record-serializers": {
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-9.0.4.tgz",
+			"integrity": "sha512-17w/VL5rZ9NOZiggrlLaYhg8WcuFYuqZU9i0lWqRp9Ed9n8vQ/ihoHJoQeAq03g+1F6yylQp5wXNZ/49RLVwtQ==",
+			"dependencies": {
+				"@natlibfi/marc-record": "^7.2.2",
+				"@xmldom/xmldom": "^0.8.6",
+				"stream-json": "^1.7.5",
+				"xml2js": ">=0.4.23 <1.0.0",
+				"yargs": "^17.6.2"
+			},
+			"bin": {
+				"marc-record-serializers": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@natlibfi/passport-melinda-aleph/node_modules/@natlibfi/melinda-commons": {
+			"version": "12.0.9",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-12.0.9.tgz",
+			"integrity": "sha512-PHrYz7bOIuzUBwjmgoYkqLK3+nPMaO4TLT8+rTlBKs1P29Uv/k4EWOkOZKTrlYS2xXbGoofbsspWq3+zepjxqg==",
+			"dependencies": {
+				"@natlibfi/marc-record": "^7.2.2",
+				"@natlibfi/marc-record-serializers": "^9.0.4",
+				"@natlibfi/sru-client": "^5.0.4",
+				"debug": "^4.3.4",
+				"deep-eql": "^4.1.3",
+				"http-status": "^1.6.2",
+				"moment": "^2.29.4",
+				"nock": "^13.3.0",
+				"node-fetch": "^2.6.8"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@natlibfi/passport-melinda-aleph/node_modules/@natlibfi/sru-client": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-5.0.4.tgz",
 			"integrity": "sha512-QY4QOlmSeLYR7k/lYqEOGfpT4aEemfXWfw5DrzuR3D6vdyCOjtra3swGRMS2hG0P8/nTGBVQ/KrosmPc7l8n0A==",
@@ -3463,6 +3539,20 @@
 			},
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@natlibfi/sru-client": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.2.tgz",
+			"integrity": "sha512-s9WMEGttwCDR3hQ6L1Qn13A7nAjGE9S3cVSTHR/lfK0s4epj8PugVSXLY8GIwu6whT8RqIVeN8m49Pe7Gb6hog==",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"http-status": "^1.6.2",
+				"node-fetch": "^2.6.9",
+				"xml2js": ">=0.5.0 <1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -3548,13 +3638,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
-			"integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+			"integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/visitor-keys": "5.49.0"
+				"@typescript-eslint/types": "5.59.0",
+				"@typescript-eslint/visitor-keys": "5.59.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3564,10 +3654,37 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz",
+			"integrity": "sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "5.59.0",
+				"@typescript-eslint/utils": "5.59.0",
+				"debug": "^4.3.4",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
-			"integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+			"integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3578,13 +3695,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
-			"integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+			"integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/visitor-keys": "5.49.0",
+				"@typescript-eslint/types": "5.59.0",
+				"@typescript-eslint/visitor-keys": "5.59.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -3617,9 +3734,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -3638,18 +3755,18 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
-			"integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
+			"integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
 			"dev": true,
 			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.2.0",
 				"@types/json-schema": "^7.0.9",
 				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.49.0",
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/typescript-estree": "5.49.0",
+				"@typescript-eslint/scope-manager": "5.59.0",
+				"@typescript-eslint/types": "5.59.0",
+				"@typescript-eslint/typescript-estree": "5.59.0",
 				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0",
 				"semver": "^7.3.7"
 			},
 			"engines": {
@@ -3676,9 +3793,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -3697,12 +3814,12 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
-			"integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+			"integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.49.0",
+				"@typescript-eslint/types": "5.59.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -3714,18 +3831,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+			"integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.8.6",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
-			"integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
+			"version": "0.8.7",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
+			"integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg==",
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -4435,12 +4555,12 @@
 			"dev": true
 		},
 		"node_modules/deepmerge-ts": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.2.2.tgz",
-			"integrity": "sha512-Ka3Kb21tiWjvQvS9U+1Dx+aqFAHsdTnMdYptLTmC2VAmDFMugWMY1e15aTODstipmCun8iNuqeSfcx6rsUUk0Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
+			"integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
 			"dev": true,
 			"engines": {
-				"node": ">=12.4.0"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/define-properties": {
@@ -4647,12 +4767,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.32.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-			"integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.38.0.tgz",
+			"integrity": "sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.4.1",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@eslint/eslintrc": "^2.0.2",
+				"@eslint/js": "8.38.0",
 				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -4663,10 +4786,9 @@
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^7.1.1",
-				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"eslint-visitor-keys": "^3.4.0",
+				"espree": "^9.5.1",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
@@ -4687,7 +4809,6 @@
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
-				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
@@ -4703,28 +4824,32 @@
 			}
 		},
 		"node_modules/eslint-plugin-functional": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-4.4.1.tgz",
-			"integrity": "sha512-YhSfHS52Si62Sn126g9wGx+XnWMoWhwEt6ctVXfcJj+xMUiggjOqUVMca7fuLNzX8jYiNBIeU1Y0teHGePZ3NA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-5.0.8.tgz",
+			"integrity": "sha512-rXC5THzqqSXUrbTBG+dLLYn10Af0C9Df+N4TT3onPrOz+kgInshLJdRAvEcV+8HHNsZyDrNLcgWh5jzVaAnleQ==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "ko-fi",
+					"url": "https://ko-fi.com/rebeccastevens"
+				}
+			],
 			"dependencies": {
-				"@typescript-eslint/utils": "^5.10.2",
-				"deepmerge-ts": "^4.0.3",
+				"@typescript-eslint/type-utils": "^5.50.0",
+				"@typescript-eslint/utils": "^5.50.0",
+				"deepmerge-ts": "^5.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"semver": "^7.3.7"
+				"is-immutable-type": "^1.2.5",
+				"semver": "^7.3.8"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": ">=16.10.0"
 			},
 			"peerDependencies": {
 				"eslint": "^8.0.0",
-				"tsutils": "^3.0.0",
-				"typescript": "^3.4.1 || ^4.0.0"
+				"typescript": ">=4.0.2"
 			},
 			"peerDependenciesMeta": {
-				"tsutils": {
-					"optional": true
-				},
 				"typescript": {
 					"optional": true
 				}
@@ -4755,9 +4880,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-functional/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -4786,24 +4911,6 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dev": true,
-			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5"
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
@@ -4890,12 +4997,15 @@
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+			"integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint/node_modules/estraverse": {
@@ -4956,14 +5066,14 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+			"integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4973,18 +5083,21 @@
 			}
 		},
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+			"integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
@@ -5932,6 +6045,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-immutable-type": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-1.2.9.tgz",
+			"integrity": "sha512-DDx04RjLpGNT4vtF49vGW5CECP6lAx8SL2keq99ogIxwLvJPBvgThdhb43ED5uYO4nq0kZ51tMj7VdCCQgdZ5Q==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/type-utils": "^5.55.0"
+			},
+			"peerDependencies": {
+				"eslint": "*",
+				"typescript": ">=4.7.4"
+			}
+		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -6093,9 +6219,9 @@
 			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
 		},
 		"node_modules/isbn3": {
-			"version": "1.1.30",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.30.tgz",
-			"integrity": "sha512-yxEhOUYle5BV+RgX+T8tpabeGpRiyhWwdivOKqckJLgb6RwkYLgqZIIlHEIRRBLJ39aQC/qcJ4DkJxfOBEBukQ==",
+			"version": "1.1.35",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.35.tgz",
+			"integrity": "sha512-T/EWdqaoJODQS3nB3ohLHFeDl3MjaSVnpi9lvx8NeXybrJdMusTDyysfJ4NJNHVVhaNDHEeSvPoQXWvOEkmGtg==",
 			"bin": {
 				"isbn": "bin/isbn",
 				"isbn-audit": "bin/isbn-audit",
@@ -6483,9 +6609,9 @@
 			}
 		},
 		"node_modules/node-fetch": {
-			"version": "2.6.8",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
-			"integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+			"integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -6526,9 +6652,9 @@
 			"integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
 		},
 		"node_modules/nodemon": {
-			"version": "2.0.20",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
-			"integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
+			"version": "2.0.22",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
+			"integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
 			"dependencies": {
 				"chokidar": "^3.5.2",
 				"debug": "^3.2.7",
@@ -7119,18 +7245,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
 		"node_modules/regexpu-core": {
@@ -7786,9 +7900,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
 			"dev": true,
 			"peer": true,
 			"bin": {
@@ -7796,7 +7910,7 @@
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=12.20"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -8253,9 +8367,9 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"node_modules/yargs": {
-			"version": "17.6.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"version": "17.7.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+			"integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -9675,12 +9789,12 @@
 			}
 		},
 		"@babel/cli": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.20.7.tgz",
-			"integrity": "sha512-WylgcELHB66WwQqItxNILsMlaTd8/SO6SgTTjMp4uCI7P4QyH1r3nqgFmO3BfM4AtfniHgFMH3EpYFj/zynBkQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.21.0.tgz",
+			"integrity": "sha512-xi7CxyS8XjSyiwUGCfwf+brtJxjW1/ZTcBUkP10xawIEXLX5HzLn+3aXkgxozcP2UhRhtKTmQurw9Uaes7jZrA==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.8",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
 				"chokidar": "^3.4.0",
 				"commander": "^4.0.1",
@@ -9692,33 +9806,33 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+			"integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
 			"requires": {
 				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.20.10",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-			"integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg=="
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.4.tgz",
+			"integrity": "sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g=="
 		},
 		"@babel/core": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
-			"integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.4.tgz",
+			"integrity": "sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==",
 			"requires": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
-				"@babel/helper-compilation-targets": "^7.20.7",
-				"@babel/helper-module-transforms": "^7.20.11",
-				"@babel/helpers": "^7.20.7",
-				"@babel/parser": "^7.20.7",
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.21.4",
+				"@babel/generator": "^7.21.4",
+				"@babel/helper-compilation-targets": "^7.21.4",
+				"@babel/helper-module-transforms": "^7.21.2",
+				"@babel/helpers": "^7.21.0",
+				"@babel/parser": "^7.21.4",
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.12",
-				"@babel/types": "^7.20.7",
+				"@babel/traverse": "^7.21.4",
+				"@babel/types": "^7.21.4",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -9727,9 +9841,9 @@
 			}
 		},
 		"@babel/eslint-parser": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
-			"integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
+			"version": "7.21.3",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz",
+			"integrity": "sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==",
 			"dev": true,
 			"requires": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -9738,12 +9852,13 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-			"integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
+			"integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
 			"requires": {
-				"@babel/types": "^7.20.7",
+				"@babel/types": "^7.21.4",
 				"@jridgewell/gen-mapping": "^0.3.2",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
 			},
 			"dependencies": {
@@ -9779,27 +9894,27 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
-			"integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.4.tgz",
+			"integrity": "sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==",
 			"requires": {
-				"@babel/compat-data": "^7.20.5",
-				"@babel/helper-validator-option": "^7.18.6",
+				"@babel/compat-data": "^7.21.4",
+				"@babel/helper-validator-option": "^7.21.0",
 				"browserslist": "^4.21.3",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.0"
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.20.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
-			"integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.4.tgz",
+			"integrity": "sha512-46QrX2CQlaFRF4TkwfTt6nJD7IHq8539cCL7SDpqWSDeJKY1xylKKY5F/33mJhLZ3mFvKv2gGrVS6NkyF6qs+Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
-				"@babel/helper-member-expression-to-functions": "^7.20.7",
+				"@babel/helper-function-name": "^7.21.0",
+				"@babel/helper-member-expression-to-functions": "^7.21.0",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
 				"@babel/helper-replace-supers": "^7.20.7",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
@@ -9845,12 +9960,12 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.19.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
 			"requires": {
-				"@babel/template": "^7.18.10",
-				"@babel/types": "^7.19.0"
+				"@babel/template": "^7.20.7",
+				"@babel/types": "^7.21.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
@@ -9862,12 +9977,12 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
-			"integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.21.0.tgz",
+			"integrity": "sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.20.7"
+				"@babel/types": "^7.21.0"
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -9879,9 +9994,9 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
-			"integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
+			"version": "7.21.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+			"integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-module-imports": "^7.18.6",
@@ -9889,8 +10004,8 @@
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"@babel/helper-validator-identifier": "^7.19.1",
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.10",
-				"@babel/types": "^7.20.7"
+				"@babel/traverse": "^7.21.2",
+				"@babel/types": "^7.21.2"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -9970,9 +10085,9 @@
 			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+			"integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ=="
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.20.5",
@@ -9987,13 +10102,13 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
-			"integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
+			"integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
 			"requires": {
 				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.20.13",
-				"@babel/types": "^7.20.7"
+				"@babel/traverse": "^7.21.0",
+				"@babel/types": "^7.21.0"
 			}
 		},
 		"@babel/highlight": {
@@ -10021,9 +10136,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-			"integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw=="
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
+			"integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw=="
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.18.6",
@@ -10068,12 +10183,12 @@
 			}
 		},
 		"@babel/plugin-proposal-class-static-block": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.20.7.tgz",
-			"integrity": "sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.21.0.tgz",
+			"integrity": "sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.20.7",
+				"@babel/helper-create-class-features-plugin": "^7.21.0",
 				"@babel/helper-plugin-utils": "^7.20.2",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			}
@@ -10162,9 +10277,9 @@
 			}
 		},
 		"@babel/plugin-proposal-optional-chaining": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.20.7.tgz",
-			"integrity": "sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz",
+			"integrity": "sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.20.2",
@@ -10183,13 +10298,13 @@
 			}
 		},
 		"@babel/plugin-proposal-private-property-in-object": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.20.5.tgz",
-			"integrity": "sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0.tgz",
+			"integrity": "sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
-				"@babel/helper-create-class-features-plugin": "^7.20.5",
+				"@babel/helper-create-class-features-plugin": "^7.21.0",
 				"@babel/helper-plugin-utils": "^7.20.2",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
 			}
@@ -10369,24 +10484,24 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.11.tgz",
-			"integrity": "sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.21.0.tgz",
+			"integrity": "sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.20.2"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.7.tgz",
-			"integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.21.0.tgz",
+			"integrity": "sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-compilation-targets": "^7.20.7",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
+				"@babel/helper-function-name": "^7.21.0",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
 				"@babel/helper-plugin-utils": "^7.20.2",
 				"@babel/helper-replace-supers": "^7.20.7",
@@ -10405,9 +10520,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.7.tgz",
-			"integrity": "sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==",
+			"version": "7.21.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.21.3.tgz",
+			"integrity": "sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.20.2"
@@ -10443,12 +10558,12 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz",
-			"integrity": "sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.21.0.tgz",
+			"integrity": "sha512-LlUYlydgDkKpIY7mcBWvyPPmMcOphEyYA27Ef4xpbh1IiDNLr0kZsos2nf92vz3IccvJI25QUwp86Eo5s6HmBQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-plugin-utils": "^7.20.2"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
@@ -10491,12 +10606,12 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.20.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
-			"integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
+			"version": "7.21.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.2.tgz",
+			"integrity": "sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.20.11",
+				"@babel/helper-module-transforms": "^7.21.2",
 				"@babel/helper-plugin-utils": "^7.20.2",
 				"@babel/helper-simple-access": "^7.20.2"
 			}
@@ -10553,9 +10668,9 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.7.tgz",
-			"integrity": "sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==",
+			"version": "7.21.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.21.3.tgz",
+			"integrity": "sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.20.2"
@@ -10655,31 +10770,31 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
-			"integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.21.4.tgz",
+			"integrity": "sha512-2W57zHs2yDLm6GD5ZpvNn71lZ0B/iypSdIeq25OurDKji6AdzV07qp4s3n1/x5BqtiGaTrPN3nerlSCaC5qNTw==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.20.1",
-				"@babel/helper-compilation-targets": "^7.20.0",
+				"@babel/compat-data": "^7.21.4",
+				"@babel/helper-compilation-targets": "^7.21.4",
 				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/helper-validator-option": "^7.18.6",
+				"@babel/helper-validator-option": "^7.21.0",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
-				"@babel/plugin-proposal-async-generator-functions": "^7.20.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.20.7",
+				"@babel/plugin-proposal-async-generator-functions": "^7.20.7",
 				"@babel/plugin-proposal-class-properties": "^7.18.6",
-				"@babel/plugin-proposal-class-static-block": "^7.18.6",
+				"@babel/plugin-proposal-class-static-block": "^7.21.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.18.6",
 				"@babel/plugin-proposal-export-namespace-from": "^7.18.9",
 				"@babel/plugin-proposal-json-strings": "^7.18.6",
-				"@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.20.7",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
 				"@babel/plugin-proposal-numeric-separator": "^7.18.6",
-				"@babel/plugin-proposal-object-rest-spread": "^7.20.2",
+				"@babel/plugin-proposal-object-rest-spread": "^7.20.7",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
-				"@babel/plugin-proposal-optional-chaining": "^7.18.9",
+				"@babel/plugin-proposal-optional-chaining": "^7.21.0",
 				"@babel/plugin-proposal-private-methods": "^7.18.6",
-				"@babel/plugin-proposal-private-property-in-object": "^7.18.6",
+				"@babel/plugin-proposal-private-property-in-object": "^7.21.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.18.6",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -10696,40 +10811,40 @@
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
-				"@babel/plugin-transform-arrow-functions": "^7.18.6",
-				"@babel/plugin-transform-async-to-generator": "^7.18.6",
+				"@babel/plugin-transform-arrow-functions": "^7.20.7",
+				"@babel/plugin-transform-async-to-generator": "^7.20.7",
 				"@babel/plugin-transform-block-scoped-functions": "^7.18.6",
-				"@babel/plugin-transform-block-scoping": "^7.20.2",
-				"@babel/plugin-transform-classes": "^7.20.2",
-				"@babel/plugin-transform-computed-properties": "^7.18.9",
-				"@babel/plugin-transform-destructuring": "^7.20.2",
+				"@babel/plugin-transform-block-scoping": "^7.21.0",
+				"@babel/plugin-transform-classes": "^7.21.0",
+				"@babel/plugin-transform-computed-properties": "^7.20.7",
+				"@babel/plugin-transform-destructuring": "^7.21.3",
 				"@babel/plugin-transform-dotall-regex": "^7.18.6",
 				"@babel/plugin-transform-duplicate-keys": "^7.18.9",
 				"@babel/plugin-transform-exponentiation-operator": "^7.18.6",
-				"@babel/plugin-transform-for-of": "^7.18.8",
+				"@babel/plugin-transform-for-of": "^7.21.0",
 				"@babel/plugin-transform-function-name": "^7.18.9",
 				"@babel/plugin-transform-literals": "^7.18.9",
 				"@babel/plugin-transform-member-expression-literals": "^7.18.6",
-				"@babel/plugin-transform-modules-amd": "^7.19.6",
-				"@babel/plugin-transform-modules-commonjs": "^7.19.6",
-				"@babel/plugin-transform-modules-systemjs": "^7.19.6",
+				"@babel/plugin-transform-modules-amd": "^7.20.11",
+				"@babel/plugin-transform-modules-commonjs": "^7.21.2",
+				"@babel/plugin-transform-modules-systemjs": "^7.20.11",
 				"@babel/plugin-transform-modules-umd": "^7.18.6",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.20.5",
 				"@babel/plugin-transform-new-target": "^7.18.6",
 				"@babel/plugin-transform-object-super": "^7.18.6",
-				"@babel/plugin-transform-parameters": "^7.20.1",
+				"@babel/plugin-transform-parameters": "^7.21.3",
 				"@babel/plugin-transform-property-literals": "^7.18.6",
-				"@babel/plugin-transform-regenerator": "^7.18.6",
+				"@babel/plugin-transform-regenerator": "^7.20.5",
 				"@babel/plugin-transform-reserved-words": "^7.18.6",
 				"@babel/plugin-transform-shorthand-properties": "^7.18.6",
-				"@babel/plugin-transform-spread": "^7.19.0",
+				"@babel/plugin-transform-spread": "^7.20.7",
 				"@babel/plugin-transform-sticky-regex": "^7.18.6",
 				"@babel/plugin-transform-template-literals": "^7.18.9",
 				"@babel/plugin-transform-typeof-symbol": "^7.18.9",
 				"@babel/plugin-transform-unicode-escapes": "^7.18.10",
 				"@babel/plugin-transform-unicode-regex": "^7.18.6",
 				"@babel/preset-modules": "^0.1.5",
-				"@babel/types": "^7.20.2",
+				"@babel/types": "^7.21.4",
 				"babel-plugin-polyfill-corejs2": "^0.3.3",
 				"babel-plugin-polyfill-corejs3": "^0.6.0",
 				"babel-plugin-polyfill-regenerator": "^0.4.1",
@@ -10751,9 +10866,9 @@
 			}
 		},
 		"@babel/register": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.18.9.tgz",
-			"integrity": "sha512-ZlbnXDcNYHMR25ITwwNKT88JiaukkdVj/nG7r3wnuXkOTHc60Uy05PwMCPre0hSkY68E6zK3xz+vUJSP2jWmcw==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.21.0.tgz",
+			"integrity": "sha512-9nKsPmYDi5DidAqJaQooxIhsLJiNMkGr8ypQ8Uic7cIox7UCDsM7HuUGxdGT7mSDTYbqzIdsOWzfBton/YJrMw==",
 			"requires": {
 				"clone-deep": "^4.0.1",
 				"find-cache-dir": "^2.0.0",
@@ -10781,26 +10896,26 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.20.13",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
-			"integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
+			"integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
 			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.20.7",
+				"@babel/code-frame": "^7.21.4",
+				"@babel/generator": "^7.21.4",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.19.0",
+				"@babel/helper-function-name": "^7.21.0",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.20.13",
-				"@babel/types": "^7.20.7",
+				"@babel/parser": "^7.21.4",
+				"@babel/types": "^7.21.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
-			"integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
+			"version": "7.21.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
+			"integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
 			"requires": {
 				"@babel/helper-string-parser": "^7.19.4",
 				"@babel/helper-validator-identifier": "^7.19.1",
@@ -10822,15 +10937,38 @@
 				"kuler": "^2.0.0"
 			}
 		},
+		"@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+					"integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+					"dev": true
+				}
+			}
+		},
+		"@eslint-community/regexpp": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+			"integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+			"dev": true
+		},
 		"@eslint/eslintrc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+			"integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
+				"espree": "^9.5.1",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -10840,15 +10978,21 @@
 			},
 			"dependencies": {
 				"globals": {
-					"version": "13.19.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-					"integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+					"version": "13.20.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+					"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 					"dev": true,
 					"requires": {
 						"type-fest": "^0.20.2"
 					}
 				}
 			}
+		},
+		"@eslint/js": {
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
+			"integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
+			"dev": true
 		},
 		"@humanwhocodes/config-array": {
 			"version": "0.11.8",
@@ -10907,19 +11051,16 @@
 			}
 		},
 		"@natlibfi/eslint-config-melinda-backend": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-2.0.2.tgz",
-			"integrity": "sha512-eQlj3IkrOdwti8DcuXMg+GxbL9GC919qQUsvieeL/WS3peDbAGF9R3NtdkyJkZdidtrFSd5pc1zuQos3oxToMA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.0.tgz",
+			"integrity": "sha512-Nn/jPwvwSY44xczjDiU0eR4t3Awbfc/nYrromiSn6Atx7h6V87rcXrAr1E1QtXKDWg/+7b36zNdBxO5mkaBliA==",
 			"dev": true,
 			"requires": {
-				"@babel/eslint-parser": "^7.18.9",
-				"eslint-plugin-functional": "^4.2.2"
+				"@babel/eslint-parser": "^7.21.3",
+				"@typescript-eslint/type-utils": "^5.58.0",
+				"@typescript-eslint/utils": "^5.58.0",
+				"eslint-plugin-functional": "^5.0.7"
 			}
-		},
-		"@natlibfi/fixugen": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-1.1.0.tgz",
-			"integrity": "sha512-sZoOkCRAWU0JtVAG4pujjeGkcihqErk4+u6OFcA8AMFT1UiEXl68wJNmV6URYDGAMtVjcP2cY6QwINnmnSU2RA=="
 		},
 		"@natlibfi/issn-verify": {
 			"version": "1.0.0",
@@ -10936,42 +11077,42 @@
 			}
 		},
 		"@natlibfi/marc-record-serializers": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-9.0.4.tgz",
-			"integrity": "sha512-17w/VL5rZ9NOZiggrlLaYhg8WcuFYuqZU9i0lWqRp9Ed9n8vQ/ihoHJoQeAq03g+1F6yylQp5wXNZ/49RLVwtQ==",
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.0.4.tgz",
+			"integrity": "sha512-6qSubMuBNwcN3vskwnCjA1b52NzOdmil6Zcabq+S7a77IRZ/p2b6WlAOPGZvoBSqA1vNY7sYr2Ol/X6m3bgxog==",
 			"requires": {
 				"@natlibfi/marc-record": "^7.2.2",
-				"@xmldom/xmldom": "^0.8.6",
+				"@xmldom/xmldom": "^0.8.7",
 				"stream-json": "^1.7.5",
-				"xml2js": ">=0.4.23 <1.0.0",
-				"yargs": "^17.6.2"
+				"xml2js": ">=0.5.0 <1.0.0",
+				"yargs": "^17.7.1"
 			}
 		},
 		"@natlibfi/marc-record-validate": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-7.0.3.tgz",
-			"integrity": "sha512-NLTnH8MTlIXvoxC7dJ2eOKZeJ+pBNiiTMIn6q4giFtxqAWhTxAqQgwm1PQgsVDeYl6Tmp6+9jPMtTpXwMe8oWA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-8.0.0.tgz",
+			"integrity": "sha512-jhj3Vll+5wHdl8DVINgRcjZSGc2N9ZM7tOGq9opfWYerARasciA1Ds/Qe45/NP3KJflN16bwk3o7oJ4FTTnYdg==",
 			"requires": {
-				"@babel/runtime": "^7.19.0",
-				"@natlibfi/marc-record": "^7.2.1"
+				"@babel/runtime": "^7.20.13",
+				"@natlibfi/marc-record": "^7.2.2"
 			}
 		},
 		"@natlibfi/marc-record-validators-melinda": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-9.1.1.tgz",
-			"integrity": "sha512-Z1njdjkDYDbxqZ+romxzqKAjIC6cv8NPlntIpexU517sDljoRnGvJsUybTVG/wd9rWoU0nvAdS+17Q8lH+iycA==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.3.2.tgz",
+			"integrity": "sha512-zOvGti2AK33snhFDYuSKCKvcgsBX2xzZZ97morxA9WdjKWgTErBoPo3WmOX3zhLT8Ac5Rdyd4/uNGiolG0XLqw==",
 			"requires": {
-				"@babel/register": "^7.18.9",
+				"@babel/register": "^7.21.0",
 				"@natlibfi/issn-verify": "^1.0.0",
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-validate": "^7.0.2",
+				"@natlibfi/marc-record-validate": "^8.0.0",
 				"cld3-asm": "^3.1.1",
 				"clone": "^2.1.2",
 				"debug": "^4.3.4",
-				"isbn3": "^1.1.28",
+				"isbn3": "^1.1.35",
 				"langs": "^2.0.0",
-				"node-fetch": "^2.6.7",
-				"xml2js": ">=0.4.23 <1.0.0"
+				"node-fetch": "^2.6.9",
+				"xml2js": ">=0.5.0 <1.0.0"
 			}
 		},
 		"@natlibfi/melinda-backend-commons": {
@@ -10996,13 +11137,13 @@
 			}
 		},
 		"@natlibfi/melinda-commons": {
-			"version": "12.0.9",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-12.0.9.tgz",
-			"integrity": "sha512-PHrYz7bOIuzUBwjmgoYkqLK3+nPMaO4TLT8+rTlBKs1P29Uv/k4EWOkOZKTrlYS2xXbGoofbsspWq3+zepjxqg==",
+			"version": "13.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.4.tgz",
+			"integrity": "sha512-xcNHbNFbG4fPFRQroQmXyhoHMGD2Ath/CslePzDGLpYDTxHS/vPcPIXfSNFQQXfhcBOBDKF1Z4OKuJMRaNhg2w==",
 			"requires": {
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-serializers": "^9.0.4",
-				"@natlibfi/sru-client": "^5.0.4",
+				"@natlibfi/marc-record-serializers": "^10.0.4",
+				"@natlibfi/sru-client": "^6.0.2",
 				"debug": "^4.3.4",
 				"deep-eql": "^4.1.3",
 				"http-status": "^1.6.2",
@@ -11012,17 +11153,16 @@
 			}
 		},
 		"@natlibfi/melinda-rest-api-commons": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-3.0.6.tgz",
-			"integrity": "sha512-yMtOnh2cSVXu1pDsmYOcY94SuYFHs/A5fdgoAC5Bm1H40kvBlqLLAxE1kSr/huVSiYAfe0Aqhn/41YpZnNaDpw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.0.4.tgz",
+			"integrity": "sha512-K4cA2O6lKXERi7xZ08r9QQBFkhEwe8eiIAE0Sv11HF3u4+MEKEPEepe/AyQILQBBgZBWu4GPe7k5HkGImIVrOQ==",
 			"requires": {
-				"@natlibfi/fixugen": "^1.1.0",
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-serializers": "^9.0.4",
-				"@natlibfi/marc-record-validate": "^7.0.3",
-				"@natlibfi/marc-record-validators-melinda": "^9.1.1",
+				"@natlibfi/marc-record-serializers": "^10.0.4",
+				"@natlibfi/marc-record-validate": "^8.0.0",
+				"@natlibfi/marc-record-validators-melinda": "^10.3.2",
 				"@natlibfi/melinda-backend-commons": "^2.1.0",
-				"@natlibfi/melinda-commons": "^12.0.7",
+				"@natlibfi/melinda-commons": "^13.0.4",
 				"amqplib": ">=0.10.3 <1.0.0",
 				"debug": "^4.3.4",
 				"http-status": "^1.6.2",
@@ -11042,17 +11182,58 @@
 				"node-fetch": "^2.6.7",
 				"passport": ">=0.6.0 <1.0.0",
 				"passport-http": ">=0.3.0 <1.0.0"
+			},
+			"dependencies": {
+				"@natlibfi/marc-record-serializers": {
+					"version": "9.0.4",
+					"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-9.0.4.tgz",
+					"integrity": "sha512-17w/VL5rZ9NOZiggrlLaYhg8WcuFYuqZU9i0lWqRp9Ed9n8vQ/ihoHJoQeAq03g+1F6yylQp5wXNZ/49RLVwtQ==",
+					"requires": {
+						"@natlibfi/marc-record": "^7.2.2",
+						"@xmldom/xmldom": "^0.8.6",
+						"stream-json": "^1.7.5",
+						"xml2js": ">=0.4.23 <1.0.0",
+						"yargs": "^17.6.2"
+					}
+				},
+				"@natlibfi/melinda-commons": {
+					"version": "12.0.9",
+					"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-12.0.9.tgz",
+					"integrity": "sha512-PHrYz7bOIuzUBwjmgoYkqLK3+nPMaO4TLT8+rTlBKs1P29Uv/k4EWOkOZKTrlYS2xXbGoofbsspWq3+zepjxqg==",
+					"requires": {
+						"@natlibfi/marc-record": "^7.2.2",
+						"@natlibfi/marc-record-serializers": "^9.0.4",
+						"@natlibfi/sru-client": "^5.0.4",
+						"debug": "^4.3.4",
+						"deep-eql": "^4.1.3",
+						"http-status": "^1.6.2",
+						"moment": "^2.29.4",
+						"nock": "^13.3.0",
+						"node-fetch": "^2.6.8"
+					}
+				},
+				"@natlibfi/sru-client": {
+					"version": "5.0.4",
+					"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-5.0.4.tgz",
+					"integrity": "sha512-QY4QOlmSeLYR7k/lYqEOGfpT4aEemfXWfw5DrzuR3D6vdyCOjtra3swGRMS2hG0P8/nTGBVQ/KrosmPc7l8n0A==",
+					"requires": {
+						"debug": "^4.3.4",
+						"http-status": "^1.5.2",
+						"node-fetch": "^2.6.7",
+						"xml2js": ">=0.4.23 <1.0.0"
+					}
+				}
 			}
 		},
 		"@natlibfi/sru-client": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-5.0.4.tgz",
-			"integrity": "sha512-QY4QOlmSeLYR7k/lYqEOGfpT4aEemfXWfw5DrzuR3D6vdyCOjtra3swGRMS2hG0P8/nTGBVQ/KrosmPc7l8n0A==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.2.tgz",
+			"integrity": "sha512-s9WMEGttwCDR3hQ6L1Qn13A7nAjGE9S3cVSTHR/lfK0s4epj8PugVSXLY8GIwu6whT8RqIVeN8m49Pe7Gb6hog==",
 			"requires": {
 				"debug": "^4.3.4",
-				"http-status": "^1.5.2",
-				"node-fetch": "^2.6.7",
-				"xml2js": ">=0.4.23 <1.0.0"
+				"http-status": "^1.6.2",
+				"node-fetch": "^2.6.9",
+				"xml2js": ">=0.5.0 <1.0.0"
 			}
 		},
 		"@nicolo-ribaudo/chokidar-2": {
@@ -11129,29 +11310,41 @@
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
-			"integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+			"integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/visitor-keys": "5.49.0"
+				"@typescript-eslint/types": "5.59.0",
+				"@typescript-eslint/visitor-keys": "5.59.0"
+			}
+		},
+		"@typescript-eslint/type-utils": {
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz",
+			"integrity": "sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/typescript-estree": "5.59.0",
+				"@typescript-eslint/utils": "5.59.0",
+				"debug": "^4.3.4",
+				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
-			"integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+			"integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
-			"integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+			"integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/visitor-keys": "5.49.0",
+				"@typescript-eslint/types": "5.59.0",
+				"@typescript-eslint/visitor-keys": "5.59.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -11169,9 +11362,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+					"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -11186,18 +11379,18 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
-			"integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
+			"integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
 			"dev": true,
 			"requires": {
+				"@eslint-community/eslint-utils": "^4.2.0",
 				"@types/json-schema": "^7.0.9",
 				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.49.0",
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/typescript-estree": "5.49.0",
+				"@typescript-eslint/scope-manager": "5.59.0",
+				"@typescript-eslint/types": "5.59.0",
+				"@typescript-eslint/typescript-estree": "5.59.0",
 				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0",
 				"semver": "^7.3.7"
 			},
 			"dependencies": {
@@ -11211,9 +11404,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+					"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -11228,27 +11421,27 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
-			"integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
+			"version": "5.59.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+			"integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.49.0",
+				"@typescript-eslint/types": "5.59.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"dependencies": {
 				"eslint-visitor-keys": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+					"integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
 					"dev": true
 				}
 			}
 		},
 		"@xmldom/xmldom": {
-			"version": "0.8.6",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
-			"integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg=="
+			"version": "0.8.7",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
+			"integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg=="
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -11745,9 +11938,9 @@
 			"dev": true
 		},
 		"deepmerge-ts": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.2.2.tgz",
-			"integrity": "sha512-Ka3Kb21tiWjvQvS9U+1Dx+aqFAHsdTnMdYptLTmC2VAmDFMugWMY1e15aTODstipmCun8iNuqeSfcx6rsUUk0Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
+			"integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
 			"dev": true
 		},
 		"define-properties": {
@@ -11908,12 +12101,15 @@
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 		},
 		"eslint": {
-			"version": "8.32.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-			"integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.38.0.tgz",
+			"integrity": "sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.4.1",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@eslint/eslintrc": "^2.0.2",
+				"@eslint/js": "8.38.0",
 				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -11924,10 +12120,9 @@
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^7.1.1",
-				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"eslint-visitor-keys": "^3.4.0",
+				"espree": "^9.5.1",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
@@ -11948,7 +12143,6 @@
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
-				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
@@ -12005,9 +12199,9 @@
 					}
 				},
 				"eslint-visitor-keys": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+					"integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
 					"dev": true
 				},
 				"estraverse": {
@@ -12052,15 +12246,17 @@
 			}
 		},
 		"eslint-plugin-functional": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-4.4.1.tgz",
-			"integrity": "sha512-YhSfHS52Si62Sn126g9wGx+XnWMoWhwEt6ctVXfcJj+xMUiggjOqUVMca7fuLNzX8jYiNBIeU1Y0teHGePZ3NA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-5.0.8.tgz",
+			"integrity": "sha512-rXC5THzqqSXUrbTBG+dLLYn10Af0C9Df+N4TT3onPrOz+kgInshLJdRAvEcV+8HHNsZyDrNLcgWh5jzVaAnleQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "^5.10.2",
-				"deepmerge-ts": "^4.0.3",
+				"@typescript-eslint/type-utils": "^5.50.0",
+				"@typescript-eslint/utils": "^5.50.0",
+				"deepmerge-ts": "^5.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"semver": "^7.3.7"
+				"is-immutable-type": "^1.2.5",
+				"semver": "^7.3.8"
 			},
 			"dependencies": {
 				"escape-string-regexp": {
@@ -12079,9 +12275,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+					"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -12105,15 +12301,6 @@
 				"estraverse": "^4.1.1"
 			}
 		},
-		"eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dev": true,
-			"requires": {
-				"eslint-visitor-keys": "^2.0.0"
-			}
-		},
 		"eslint-visitor-keys": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
@@ -12121,28 +12308,28 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+			"integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.0"
 			},
 			"dependencies": {
 				"eslint-visitor-keys": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+					"integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
 					"dev": true
 				}
 			}
 		},
 		"esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
@@ -12834,6 +13021,15 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-immutable-type": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-1.2.9.tgz",
+			"integrity": "sha512-DDx04RjLpGNT4vtF49vGW5CECP6lAx8SL2keq99ogIxwLvJPBvgThdhb43ED5uYO4nq0kZ51tMj7VdCCQgdZ5Q==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/type-utils": "^5.55.0"
+			}
+		},
 		"is-negative-zero": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -12938,9 +13134,9 @@
 			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
 		},
 		"isbn3": {
-			"version": "1.1.30",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.30.tgz",
-			"integrity": "sha512-yxEhOUYle5BV+RgX+T8tpabeGpRiyhWwdivOKqckJLgb6RwkYLgqZIIlHEIRRBLJ39aQC/qcJ4DkJxfOBEBukQ=="
+			"version": "1.1.35",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.35.tgz",
+			"integrity": "sha512-T/EWdqaoJODQS3nB3ohLHFeDl3MjaSVnpi9lvx8NeXybrJdMusTDyysfJ4NJNHVVhaNDHEeSvPoQXWvOEkmGtg=="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -13237,9 +13433,9 @@
 			}
 		},
 		"node-fetch": {
-			"version": "2.6.8",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
-			"integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+			"integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
 			"requires": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -13271,9 +13467,9 @@
 			"integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
 		},
 		"nodemon": {
-			"version": "2.0.20",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
-			"integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
+			"version": "2.0.22",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
+			"integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
 			"requires": {
 				"chokidar": "^3.5.2",
 				"debug": "^3.2.7",
@@ -13691,12 +13887,6 @@
 				"define-properties": "^1.1.3",
 				"functions-have-names": "^1.2.2"
 			}
-		},
-		"regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true
 		},
 		"regexpu-core": {
 			"version": "5.2.2",
@@ -14192,9 +14382,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
 			"dev": true,
 			"peer": true
 		},
@@ -14520,9 +14710,9 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"yargs": {
-			"version": "17.6.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"version": "17.7.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+			"integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
 			"requires": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.0.6",
+	"version": "3.0.7-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -30,33 +30,33 @@
 		"prod": "NODE_ENV=production npm run build && npm run start"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.20.13",
-		"@natlibfi/marc-record-serializers": "^9.0.4",
+		"@babel/runtime": "^7.21.0",
+		"@natlibfi/marc-record-serializers": "^10.0.4",
 		"@natlibfi/melinda-backend-commons": "^2.1.0",
-		"@natlibfi/melinda-commons": "^12.0.7",
-		"@natlibfi/melinda-rest-api-commons": "^3.0.6",
+		"@natlibfi/melinda-commons": "^13.0.4",
+		"@natlibfi/melinda-rest-api-commons": "^4.0.4",
 		"@natlibfi/passport-melinda-aleph": "^2.0.4",
-		"@natlibfi/sru-client": "^5.0.4",
-		"body-parser": "^1.20.1",
+		"@natlibfi/sru-client": "^6.0.2",
+		"body-parser": "^1.20.2",
 		"express": "^4.18.2",
 		"http-status": "^1.6.2",
 		"moment": "^2.29.4",
 		"mongo-sanitize": "^1.1.0",
-		"nodemon": "^2.0.20",
+		"nodemon": "^2.0.22",
 		"passport": "^0.6.0",
 		"passport-http": "^0.3.0",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.20.7",
-		"@babel/core": "^7.20.12",
-		"@babel/eslint-parser": "^7.19.1",
+		"@babel/cli": "^7.21.0",
+		"@babel/core": "^7.21.4",
+		"@babel/eslint-parser": "^7.21.3",
 		"@babel/node": "^7.20.7",
-		"@babel/preset-env": "^7.20.2",
-		"@babel/register": "^7.18.9",
-		"@natlibfi/eslint-config-melinda-backend": "^2.0.2",
+		"@babel/preset-env": "^7.21.4",
+		"@babel/register": "^7.21.0",
+		"@natlibfi/eslint-config-melinda-backend": "^3.0.0",
 		"cross-env": "^7.0.3",
-		"eslint": "^8.32.0"
+		"eslint": "^8.38.0"
 	},
 	"eslintConfig": {
 		"extends": "@natlibfi/melinda-backend"

--- a/src/app.js
+++ b/src/app.js
@@ -13,7 +13,8 @@ export default async function ({
   xServiceURL, userLibrary,
   ownAuthzURL, ownAuthzApiKey,
   sruUrl, amqpUrl, mongoUri,
-  pollWaitTime, recordType
+  pollWaitTime, recordType,
+  requireAuthForRead
 }) {
   const logger = createLogger();
   const server = await initExpress();
@@ -46,7 +47,7 @@ export default async function ({
     app.use(bodyParser.text({limit: '5MB', type: '*/*'}));
     app.use('/apidoc', createApiDocRouter());
     app.use('/logs', passport.authenticate('melinda', {session: false}), await createLogsRouter({mongoUri}));
-    app.use('/', await createPrioRouter({sruUrl, amqpUrl, mongoUri, pollWaitTime, recordType}));
+    app.use('/', await createPrioRouter({sruUrl, amqpUrl, mongoUri, pollWaitTime, recordType, requireAuthForRead}));
     app.use(handleError);
 
     return app.listen(httpPort, () => logger.info(`Started Melinda REST API for ${recordType} records in port ${httpPort}`));

--- a/src/config.js
+++ b/src/config.js
@@ -60,3 +60,5 @@ export const CONTENT_TYPES = [
   {contentType: 'application/alephseq', conversionFormat: CONVERSION_FORMATS.ALEPHSEQ, allowPrio: false, allowBulk: true}
 ];
 
+export const DEFAULT_ACCEPT = readEnvironmentVariable('DEFAULT_ACCEPT', {defaultValue: 'application/json'});
+

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@
 *
 * RESTful API for Melinda
 *
-* Copyright (C) 2018-2019 University Of Helsinki (The National Library Of Finland)
+* Copyright (C) 2018-2019, 2023 University Of Helsinki (The National Library Of Finland)
 *
 * This file is part of melinda-rest-api-http
 *
@@ -50,6 +50,8 @@ export const mongoUri = readEnvironmentVariable('MONGO_URI', {defaultValue: 'mon
 export const pollWaitTime = readEnvironmentVariable('POLL_WAIT_TIME', {defaultValue: 100, format: v => Number(v)});
 
 export const recordType = readEnvironmentVariable('RECORD_TYPE', {defaultValue: 'bib'});
+
+export const requireAuthForRead = readEnvironmentVariable('REQUIRE_AUTH_FOR_READ', {defaultValue: 0, format: v => parseBoolean(v)});
 
 export const CONTENT_TYPES = [
   {contentType: 'application/json', conversionFormat: CONVERSION_FORMATS.JSON, allowPrio: true, allowBulk: true},

--- a/src/interfaces/prio.js
+++ b/src/interfaces/prio.js
@@ -214,7 +214,7 @@ export default async function ({sruUrl, amqpUrl, mongoUri, pollWaitTime}) {
     // Note: there can be timeout result and the create/update to Melinda can still be done, if timeout happens when while job is being imported
     const result = await mongoOperator.queryById({correlationId, checkModTime: true});
 
-    if (queueItemState !== result.queueItemState) { // eslint-disable-line functional/no-conditional-statement
+    if (queueItemState !== result.queueItemState) { // eslint-disable-line functional/no-conditional-statements
       logger.debug(`Queue item ${correlationId}, state ${result.queueItemState}`);
     }
 

--- a/src/interfaces/utils.js
+++ b/src/interfaces/utils.js
@@ -17,34 +17,34 @@ const logger = createLogger();
 export function generateQuery({id, correlationId, queueItemState, creationTime, modificationTime, skip, limit}) {
   const doc = {};
 
-  if (skip) { // eslint-disable-line functional/no-conditional-statement
+  if (skip) { // eslint-disable-line functional/no-conditional-statements
     doc.skip = skip; // eslint-disable-line functional/immutable-data
   }
 
-  if (limit) { // eslint-disable-line functional/no-conditional-statement
+  if (limit) { // eslint-disable-line functional/no-conditional-statements
     doc.limit = limit; // eslint-disable-line functional/immutable-data
   }
 
   // We parse both 'id' and 'correlationId' in query as correlationId in Mongo
 
-  if (id) { // eslint-disable-line functional/no-conditional-statement
+  if (id) { // eslint-disable-line functional/no-conditional-statements
     doc.correlationId = sanitize(id); // eslint-disable-line functional/immutable-data
   }
 
-  if (correlationId) { // eslint-disable-line functional/no-conditional-statement
+  if (correlationId) { // eslint-disable-line functional/no-conditional-statements
     doc.correlationId = sanitize(correlationId); // eslint-disable-line functional/immutable-data
   }
 
   // we could have here also final: ABORT, DONE, ERROR, active: !final
-  if (queueItemState) { // eslint-disable-line functional/no-conditional-statement
+  if (queueItemState) { // eslint-disable-line functional/no-conditional-statements
     doc.queueItemState = queueItemState; // eslint-disable-line functional/immutable-data
   }
 
   if (creationTime) {
     const timestampArray = JSON.parse(creationTime);
-    if (creationTime.length === 1) { // eslint-disable-line functional/no-conditional-statement
+    if (creationTime.length === 1) { // eslint-disable-line functional/no-conditional-statements
       doc.creationTime = formatTime(timestampArray[0]); // eslint-disable-line functional/immutable-data
-    } else { // eslint-disable-line functional/no-conditional-statement
+    } else { // eslint-disable-line functional/no-conditional-statements
       doc.$and = [ // eslint-disable-line functional/immutable-data
         {creationTime: {$gte: formatTime(timestampArray[0])}},
         {creationTime: {$lte: formatTime(timestampArray[1])}}
@@ -54,9 +54,9 @@ export function generateQuery({id, correlationId, queueItemState, creationTime, 
 
   if (modificationTime) {
     const timestampArray = JSON.parse(modificationTime);
-    if (modificationTime.length === 1) { // eslint-disable-line functional/no-conditional-statement
+    if (modificationTime.length === 1) { // eslint-disable-line functional/no-conditional-statements
       doc.modificationTime = formatTime(timestampArray[0]); // eslint-disable-line functional/immutable-data
-    } else { // eslint-disable-line functional/no-conditional-statement
+    } else { // eslint-disable-line functional/no-conditional-statements
       doc.$and = [ // eslint-disable-line functional/immutable-data
         {modificationTime: {$gte: formatTime(timestampArray[0])}},
         {modificationTime: {$lte: formatTime(timestampArray[1])}}

--- a/src/routes/api-doc.js
+++ b/src/routes/api-doc.js
@@ -4,7 +4,7 @@
 *
 * RESTful API for Melinda
 *
-* Copyright (C) 2018-2019 University Of Helsinki (The National Library Of Finland)
+* Copyright (C) 2018-2019, 2023 University Of Helsinki (The National Library Of Finland)
 *
 * This file is part of melinda-rest-api-http
 *

--- a/src/routes/prio.js
+++ b/src/routes/prio.js
@@ -47,6 +47,17 @@ export default async ({sruUrl, amqpUrl, mongoUri, pollWaitTime, recordType, requ
     sruUrl, amqpUrl, mongoUri, pollWaitTime
   });
 
+  // Require authentication before reading if requireAuthForRead is true
+  if (requireAuthForRead) {
+    return new Router()
+      .use(passport.authenticate('melinda', {session: false}))
+      .use(checkQueryParams)
+      .get('/:id', checkAcceptHeader, readResource)
+      .get('/prio/', authorizeKVPOnly, getPrioLogs)
+      .post('/', checkContentType, createResource)
+      .post('/:id', checkContentType, updateResource);
+  }
+
   return new Router()
     .use(checkQueryParams)
     .get('/:id', checkAcceptHeader, readResource)
@@ -64,10 +75,6 @@ export default async ({sruUrl, amqpUrl, mongoUri, pollWaitTime, recordType, requ
   */
 
   async function readResource(req, res, next) {
-    // eslint-disable-next-line functional/no-conditional-statement
-    if (requireAuthForRead) {
-      logger.debug(`We would need authorization here`);
-    }
     logger.silly('routes/Prio readResource');
     try {
       const type = req.headers.accept;

--- a/src/routes/routeUtils.js
+++ b/src/routes/routeUtils.js
@@ -21,7 +21,7 @@ export function sanitizeCataloger(passportCataloger, queryCataloger) {
     return {id: queryCataloger, authorization};
   }
 
-  if (!authorization.includes('KVP') && queryCataloger !== undefined) { // eslint-disable-line functional/no-conditional-statement
+  if (!authorization.includes('KVP') && queryCataloger !== undefined) { // eslint-disable-line functional/no-conditional-statements
     throw new HttpError(httpStatus.FORBIDDEN, 'Account has no permission to do this request');
   }
 

--- a/src/routes/routeUtils.js
+++ b/src/routes/routeUtils.js
@@ -31,6 +31,11 @@ export function sanitizeCataloger(passportCataloger, queryCataloger) {
 // Note: checkAcceptHeader currently works only for prio
 export function checkAcceptHeader(req, res, next) {
   logger.debug(`routesUtils:checkAcceptHeader: accept: ${req.headers.accept}`);
+
+  if (req.headers.accept === '*/*') {
+    return next();
+  }
+
   if (req.headers.accept === undefined || !CONTENT_TYPES.find(({contentType, allowPrio}) => contentType === req.headers.accept && allowPrio === true)) {
     return res.status(httpStatus.UNSUPPORTED_MEDIA_TYPE).send('Invalid Accept header');
   }


### PR DESCRIPTION
Add two features:
- Optionally require authentication for prio read (configurable, default is false)
- If a prio read request is missing a specified Accept-header, use default content-type for record in response (configurable, default is 'application/json')

Remove duplicate (non-reachable?) code for serveApiDoc in prio