### PR TITLE
Dependency update (#105)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.0.7",
+	"version": "3.0.8-alpha.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.0.7",
+			"version": "3.0.8-alpha.1",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.21.0",
@@ -3083,9 +3083,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-			"integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+			"version": "7.21.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+			"integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.11"
 			},
@@ -3405,16 +3405,16 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.1.0.tgz",
-			"integrity": "sha512-h4Aeckj5yi9zepgXAneSypjTaoQ9E3A7GEg33uFBSfJUnzCTYX7TEzQVmMBeOeRNsmH/CkUbcEMWl7xgWcyOrQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.0.tgz",
+			"integrity": "sha512-5qwVKosaeKRuOwmsY12P8pZD6ZOj6LwyGX0HKrHqE7I/D963WFXz6j7TzumoHF+XuPs3nnevtrlEZmlSuCBphA==",
 			"dependencies": {
 				"base64-url": "^2.3.3",
 				"debug": "^4.3.4",
 				"express-winston": "^4.2.0",
 				"moment": "^2.29.4",
 				"pretty-print-ms": "^1.0.5",
-				"uuid": "^8.3.2",
+				"uuid": "^9.0.0",
 				"winston": "^3.8.2"
 			},
 			"bin": {
@@ -3422,15 +3422,7 @@
 				"gen-jwt-token": "dist/gen-jwt-token.js"
 			},
 			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@natlibfi/melinda-backend-commons/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
@@ -10878,9 +10870,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-			"integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+			"version": "7.21.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+			"integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
 			"requires": {
 				"regenerator-runtime": "^0.13.11"
 			}
@@ -11116,24 +11108,17 @@
 			}
 		},
 		"@natlibfi/melinda-backend-commons": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.1.0.tgz",
-			"integrity": "sha512-h4Aeckj5yi9zepgXAneSypjTaoQ9E3A7GEg33uFBSfJUnzCTYX7TEzQVmMBeOeRNsmH/CkUbcEMWl7xgWcyOrQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.0.tgz",
+			"integrity": "sha512-5qwVKosaeKRuOwmsY12P8pZD6ZOj6LwyGX0HKrHqE7I/D963WFXz6j7TzumoHF+XuPs3nnevtrlEZmlSuCBphA==",
 			"requires": {
 				"base64-url": "^2.3.3",
 				"debug": "^4.3.4",
 				"express-winston": "^4.2.0",
 				"moment": "^2.29.4",
 				"pretty-print-ms": "^1.0.5",
-				"uuid": "^8.3.2",
+				"uuid": "^9.0.0",
 				"winston": "^3.8.2"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "8.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-				}
 			}
 		},
 		"@natlibfi/melinda-commons": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.0.7",
+	"version": "3.0.8-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
* Bump @babel/runtime from 7.21.0 to 7.21.5 (#103)
* Bump @natlibfi/melinda-backend-commons from 2.1.0 to 2.2.0 (#102)

* 3.0.8-alpha.1