### PR TITLE
Bump fast-xml-parser and @aws-sdk/credential-providers (#130)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,66 +133,47 @@
 				"tslib": "^1.11.1"
 			}
 		},
-		"node_modules/@aws-sdk/abort-controller": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
-			"integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.347.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.347.1.tgz",
-			"integrity": "sha512-E7hyfLORHmGFXBiN+7/8cg6h6G4b2e7mRaqdMWkAcWAalrNGrxeeNTm17BdOLpxKBfT5u7II9+1fjDOG4LLecQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.378.0.tgz",
+			"integrity": "sha512-uN2qQaVwYigo0aDe1KhyanXYq6VyCfSK5swNopO/BjTEYvf0S65MR8BNEm8favBbC9eVGSVs3pH00WBWN8KxDw==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/client-sts": "3.347.1",
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/credential-provider-node": "3.347.0",
-				"@aws-sdk/fetch-http-handler": "3.347.0",
-				"@aws-sdk/hash-node": "3.347.0",
-				"@aws-sdk/invalid-dependency": "3.347.0",
-				"@aws-sdk/middleware-content-length": "3.347.0",
-				"@aws-sdk/middleware-endpoint": "3.347.0",
-				"@aws-sdk/middleware-host-header": "3.347.0",
-				"@aws-sdk/middleware-logger": "3.347.0",
-				"@aws-sdk/middleware-recursion-detection": "3.347.0",
-				"@aws-sdk/middleware-retry": "3.347.0",
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/middleware-signing": "3.347.0",
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/middleware-user-agent": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/node-http-handler": "3.347.0",
-				"@aws-sdk/smithy-client": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"@aws-sdk/util-body-length-browser": "3.310.0",
-				"@aws-sdk/util-body-length-node": "3.310.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.347.0",
-				"@aws-sdk/util-defaults-mode-node": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"@aws-sdk/util-user-agent-browser": "3.347.0",
-				"@aws-sdk/util-user-agent-node": "3.347.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"@smithy/protocol-http": "^1.0.1",
-				"@smithy/types": "^1.0.0",
+				"@aws-sdk/client-sts": "3.378.0",
+				"@aws-sdk/credential-provider-node": "3.378.0",
+				"@aws-sdk/middleware-host-header": "3.378.0",
+				"@aws-sdk/middleware-logger": "3.378.0",
+				"@aws-sdk/middleware-recursion-detection": "3.378.0",
+				"@aws-sdk/middleware-signing": "3.378.0",
+				"@aws-sdk/middleware-user-agent": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@aws-sdk/util-user-agent-browser": "3.378.0",
+				"@aws-sdk/util-user-agent-node": "3.378.0",
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/hash-node": "^2.0.1",
+				"@smithy/invalid-dependency": "^2.0.1",
+				"@smithy/middleware-content-length": "^2.0.1",
+				"@smithy/middleware-endpoint": "^2.0.1",
+				"@smithy/middleware-retry": "^2.0.1",
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/smithy-client": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.0.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.1",
+				"@smithy/util-defaults-mode-node": "^2.0.1",
+				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -200,49 +181,49 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.347.0.tgz",
-			"integrity": "sha512-AZehWCNLUXTrDavsZYRi7d84Uef20ppYJ2FY0KxqrKB3lx89mO29SfSJSC4woeW5+6ooBokq8HtKxw5ImPfRhA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.378.0.tgz",
+			"integrity": "sha512-xQ2myljd4T0W46WQVHnT61PLiIoGqcIJA6euClvSQndKqXt8fnJP6/kn2r+APIsjey823pjkEP4mZq8gYDiOOw==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/fetch-http-handler": "3.347.0",
-				"@aws-sdk/hash-node": "3.347.0",
-				"@aws-sdk/invalid-dependency": "3.347.0",
-				"@aws-sdk/middleware-content-length": "3.347.0",
-				"@aws-sdk/middleware-endpoint": "3.347.0",
-				"@aws-sdk/middleware-host-header": "3.347.0",
-				"@aws-sdk/middleware-logger": "3.347.0",
-				"@aws-sdk/middleware-recursion-detection": "3.347.0",
-				"@aws-sdk/middleware-retry": "3.347.0",
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/middleware-user-agent": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/node-http-handler": "3.347.0",
-				"@aws-sdk/smithy-client": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"@aws-sdk/util-body-length-browser": "3.310.0",
-				"@aws-sdk/util-body-length-node": "3.310.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.347.0",
-				"@aws-sdk/util-defaults-mode-node": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"@aws-sdk/util-user-agent-browser": "3.347.0",
-				"@aws-sdk/util-user-agent-node": "3.347.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"@smithy/protocol-http": "^1.0.1",
-				"@smithy/types": "^1.0.0",
+				"@aws-sdk/middleware-host-header": "3.378.0",
+				"@aws-sdk/middleware-logger": "3.378.0",
+				"@aws-sdk/middleware-recursion-detection": "3.378.0",
+				"@aws-sdk/middleware-user-agent": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@aws-sdk/util-user-agent-browser": "3.378.0",
+				"@aws-sdk/util-user-agent-node": "3.378.0",
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/hash-node": "^2.0.1",
+				"@smithy/invalid-dependency": "^2.0.1",
+				"@smithy/middleware-content-length": "^2.0.1",
+				"@smithy/middleware-endpoint": "^2.0.1",
+				"@smithy/middleware-retry": "^2.0.1",
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/smithy-client": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.0.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.1",
+				"@smithy/util-defaults-mode-node": "^2.0.1",
+				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -250,43 +231,43 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.347.0.tgz",
-			"integrity": "sha512-IBxRfPqb8f9FqpmDbzcRDfoiasj/Y47C4Gj+j3kA5T1XWyGwbDI9QnPW/rnkZTWxLUUG1LSbBNwbPD6TLoff8A==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.378.0.tgz",
+			"integrity": "sha512-+IcXH/W/TVzE0lMHuACgARgM/WxVbujGJzYUmDwj4E3uXjhTrRz69aeDk5z2EUggxKON9NOzHGZpm06VoS8uPA==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/fetch-http-handler": "3.347.0",
-				"@aws-sdk/hash-node": "3.347.0",
-				"@aws-sdk/invalid-dependency": "3.347.0",
-				"@aws-sdk/middleware-content-length": "3.347.0",
-				"@aws-sdk/middleware-endpoint": "3.347.0",
-				"@aws-sdk/middleware-host-header": "3.347.0",
-				"@aws-sdk/middleware-logger": "3.347.0",
-				"@aws-sdk/middleware-recursion-detection": "3.347.0",
-				"@aws-sdk/middleware-retry": "3.347.0",
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/middleware-user-agent": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/node-http-handler": "3.347.0",
-				"@aws-sdk/smithy-client": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"@aws-sdk/util-body-length-browser": "3.310.0",
-				"@aws-sdk/util-body-length-node": "3.310.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.347.0",
-				"@aws-sdk/util-defaults-mode-node": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"@aws-sdk/util-user-agent-browser": "3.347.0",
-				"@aws-sdk/util-user-agent-node": "3.347.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"@smithy/protocol-http": "^1.0.1",
-				"@smithy/types": "^1.0.0",
+				"@aws-sdk/middleware-host-header": "3.378.0",
+				"@aws-sdk/middleware-logger": "3.378.0",
+				"@aws-sdk/middleware-recursion-detection": "3.378.0",
+				"@aws-sdk/middleware-user-agent": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@aws-sdk/util-user-agent-browser": "3.378.0",
+				"@aws-sdk/util-user-agent-node": "3.378.0",
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/hash-node": "^2.0.1",
+				"@smithy/invalid-dependency": "^2.0.1",
+				"@smithy/middleware-content-length": "^2.0.1",
+				"@smithy/middleware-endpoint": "^2.0.1",
+				"@smithy/middleware-retry": "^2.0.1",
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/smithy-client": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.0.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.1",
+				"@smithy/util-defaults-mode-node": "^2.0.1",
+				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -294,59 +275,59 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-sso/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-sts": {
-			"version": "3.347.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.347.1.tgz",
-			"integrity": "sha512-i7vomVsbZcGD2pzOuEl0RS7yCtFcT6CVfSP1wZLwgcjAssUKTLHi65I/uSAUF0KituChw31aXlxh7EGq1uDqaA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.378.0.tgz",
+			"integrity": "sha512-u7y1I5BVjKEDK6ybA4c5smkbuoSFTBQqYX9qbCFYRErIA3qCICZB3duApcVRpdypKBzwYxUkLT/qKj4s9QTvrQ==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/credential-provider-node": "3.347.0",
-				"@aws-sdk/fetch-http-handler": "3.347.0",
-				"@aws-sdk/hash-node": "3.347.0",
-				"@aws-sdk/invalid-dependency": "3.347.0",
-				"@aws-sdk/middleware-content-length": "3.347.0",
-				"@aws-sdk/middleware-endpoint": "3.347.0",
-				"@aws-sdk/middleware-host-header": "3.347.0",
-				"@aws-sdk/middleware-logger": "3.347.0",
-				"@aws-sdk/middleware-recursion-detection": "3.347.0",
-				"@aws-sdk/middleware-retry": "3.347.0",
-				"@aws-sdk/middleware-sdk-sts": "3.347.0",
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/middleware-signing": "3.347.0",
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/middleware-user-agent": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/node-http-handler": "3.347.0",
-				"@aws-sdk/smithy-client": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"@aws-sdk/util-body-length-browser": "3.310.0",
-				"@aws-sdk/util-body-length-node": "3.310.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.347.0",
-				"@aws-sdk/util-defaults-mode-node": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"@aws-sdk/util-user-agent-browser": "3.347.0",
-				"@aws-sdk/util-user-agent-node": "3.347.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"@smithy/protocol-http": "^1.0.1",
-				"@smithy/types": "^1.0.0",
-				"fast-xml-parser": "4.2.4",
+				"@aws-sdk/credential-provider-node": "3.378.0",
+				"@aws-sdk/middleware-host-header": "3.378.0",
+				"@aws-sdk/middleware-logger": "3.378.0",
+				"@aws-sdk/middleware-recursion-detection": "3.378.0",
+				"@aws-sdk/middleware-sdk-sts": "3.378.0",
+				"@aws-sdk/middleware-signing": "3.378.0",
+				"@aws-sdk/middleware-user-agent": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@aws-sdk/util-user-agent-browser": "3.378.0",
+				"@aws-sdk/util-user-agent-node": "3.378.0",
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/hash-node": "^2.0.1",
+				"@smithy/invalid-dependency": "^2.0.1",
+				"@smithy/middleware-content-length": "^2.0.1",
+				"@smithy/middleware-endpoint": "^2.0.1",
+				"@smithy/middleware-retry": "^2.0.1",
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/smithy-client": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.0.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.1",
+				"@smithy/util-defaults-mode-node": "^2.0.1",
+				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"fast-xml-parser": "4.2.5",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -354,41 +335,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sts/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/config-resolver": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
-			"integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-config-provider": "3.310.0",
-				"@aws-sdk/util-middleware": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.347.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.347.1.tgz",
-			"integrity": "sha512-7UQmpX5Xe4OPUgVtMK4+g5yMlYTmlpbYWbJG0RnyXtxLBG2OP4iyc8LGBq9AVY/ljTYGv+LSdVorldvERHUDCA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.378.0.tgz",
+			"integrity": "sha512-UVOJH4QC/LHNkwkE7ZlOEYqyCpDL87RKM8h3hZ98Rabj2UXZ2rH7bgHJBa1fFuokHnOM5Gf3LJvgLw38FMvvwA==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.347.1",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/client-cognito-identity": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -396,19 +357,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
-			"integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz",
+			"integrity": "sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -416,47 +378,26 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/credential-provider-imds": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
-			"integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.347.0.tgz",
-			"integrity": "sha512-84TNF34ryabmVbILOq7f+/Jy8tJaskvHdax3X90qxFtXRU11kX0bf5NYL616KT0epR0VGpy50ThfIqvBwxeJfQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.378.0.tgz",
+			"integrity": "sha512-R34ELLCBTb+QkmWCaukNkT4vGeAipcL2wFN7Q2/WVSnJnRPPZSxzDK5rr78TiOPhRBu1k+aLDRNfslTZDknIIQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.347.0",
-				"@aws-sdk/credential-provider-imds": "3.347.0",
-				"@aws-sdk/credential-provider-process": "3.347.0",
-				"@aws-sdk/credential-provider-sso": "3.347.0",
-				"@aws-sdk/credential-provider-web-identity": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/credential-provider-env": "3.378.0",
+				"@aws-sdk/credential-provider-process": "3.378.0",
+				"@aws-sdk/credential-provider-sso": "3.378.0",
+				"@aws-sdk/credential-provider-web-identity": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/credential-provider-imds": "^2.0.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -464,26 +405,27 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.347.0.tgz",
-			"integrity": "sha512-ds2uxE0krl94RdQ7bstwafUXdlMeEOPgedhaheVVlj8kH+XqlZdwUUaUv1uoEI9iBzuSjKftUkIHo0xsTiwtaw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.378.0.tgz",
+			"integrity": "sha512-vULsOsmcqSD+Prp/yl/o1gvQAKd2oHuqI8snh4G0RAkEvoyb7vx2l0ShCoXOVY/wM9PQH8nxBHmVbiAQfSndNg==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.347.0",
-				"@aws-sdk/credential-provider-imds": "3.347.0",
-				"@aws-sdk/credential-provider-ini": "3.347.0",
-				"@aws-sdk/credential-provider-process": "3.347.0",
-				"@aws-sdk/credential-provider-sso": "3.347.0",
-				"@aws-sdk/credential-provider-web-identity": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/credential-provider-env": "3.378.0",
+				"@aws-sdk/credential-provider-ini": "3.378.0",
+				"@aws-sdk/credential-provider-process": "3.378.0",
+				"@aws-sdk/credential-provider-sso": "3.378.0",
+				"@aws-sdk/credential-provider-web-identity": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/credential-provider-imds": "^2.0.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -491,20 +433,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
-			"integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz",
+			"integrity": "sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -512,22 +455,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.347.0.tgz",
-			"integrity": "sha512-M1d7EnUaJbSNCmNalEbINmtFkc9wJufx7UhKtEeFwSq9KEzOMroH1MEOeiqIw9f/zE8NI/iPkVeEhw123vmBrQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.378.0.tgz",
+			"integrity": "sha512-lDPo/audYE/oERAef/VnHMe8THPCauH3Yu3DQYzCs+EWr1sIzp8vklWdMVQQI8cUlcLyYf4Dv9t8c+eJFZvrgw==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/token-providers": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/client-sso": "3.378.0",
+				"@aws-sdk/token-providers": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -535,19 +479,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
-			"integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz",
+			"integrity": "sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -555,30 +500,31 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.347.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.347.1.tgz",
-			"integrity": "sha512-2P7krq9w6egQnLxjU7IPp/Q4W8svs/NdWUKe1m17NVscop4GEAo9p26y2Ku23Jlw/lnmIpu8qHTEX+5+XEVSXg==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.378.0.tgz",
+			"integrity": "sha512-AP1/0u70z2EjU2tAHy4aKFGndaPFh4hl1bfGxL+h9xfDujyGYV0k//86BUjNw2yfCv5966jhYXi9nxIFG/05fw==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.347.1",
-				"@aws-sdk/client-sso": "3.347.0",
-				"@aws-sdk/client-sts": "3.347.1",
-				"@aws-sdk/credential-provider-cognito-identity": "3.347.1",
-				"@aws-sdk/credential-provider-env": "3.347.0",
-				"@aws-sdk/credential-provider-imds": "3.347.0",
-				"@aws-sdk/credential-provider-ini": "3.347.0",
-				"@aws-sdk/credential-provider-node": "3.347.0",
-				"@aws-sdk/credential-provider-process": "3.347.0",
-				"@aws-sdk/credential-provider-sso": "3.347.0",
-				"@aws-sdk/credential-provider-web-identity": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/client-cognito-identity": "3.378.0",
+				"@aws-sdk/client-sso": "3.378.0",
+				"@aws-sdk/client-sts": "3.378.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.378.0",
+				"@aws-sdk/credential-provider-env": "3.378.0",
+				"@aws-sdk/credential-provider-ini": "3.378.0",
+				"@aws-sdk/credential-provider-node": "3.378.0",
+				"@aws-sdk/credential-provider-process": "3.378.0",
+				"@aws-sdk/credential-provider-sso": "3.378.0",
+				"@aws-sdk/credential-provider-web-identity": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/credential-provider-imds": "^2.0.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -591,148 +537,15 @@
 			"integrity": "sha512-KaI6gPil5m9vF7DKaoXxx1ia9fxS4qG5YveErRRVknPDXXriu5M8h48YRjB6h5ZUOKuAKlSJYb0GaDe8I39fRw==",
 			"optional": true
 		},
-		"node_modules/@aws-sdk/eventstream-codec": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
-			"integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
-			"optional": true,
-			"dependencies": {
-				"@aws-crypto/crc32": "3.0.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-hex-encoding": "3.310.0",
-				"tslib": "^2.5.0"
-			}
-		},
-		"node_modules/@aws-sdk/eventstream-codec/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/fetch-http-handler": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
-			"integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/querystring-builder": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"tslib": "^2.5.0"
-			}
-		},
-		"node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/hash-node": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
-			"integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-buffer-from": "3.310.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/hash-node/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/invalid-dependency": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
-			"integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			}
-		},
-		"node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/is-array-buffer": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-			"integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/middleware-content-length": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
-			"integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/middleware-endpoint": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-			"integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-middleware": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-endpoint/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
-			"integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.378.0.tgz",
+			"integrity": "sha512-zzZZ8U3MxTgSW/bpr5wNbDuGUc/lPtB9c07bD/+F81KuGCOiPIl4PA4EyMI3tftPM9DbbcFX5ZwKi9vlZ4BWcw==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -740,18 +553,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
-			"integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz",
+			"integrity": "sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -759,19 +573,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
-			"integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz",
+			"integrity": "sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -779,52 +594,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
-		},
-		"node_modules/@aws-sdk/middleware-retry": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
-			"integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/service-error-classification": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-middleware": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"tslib": "^2.5.0",
-				"uuid": "^8.3.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"optional": true,
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-sts": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
-			"integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.378.0.tgz",
+			"integrity": "sha512-uOoE4mvlJnR7NGIbCXQA3nI4qjWHfEETX4WzamjCQBTmoXBUlSU0hCRKvG5VHSpwI3XOu7dke9fFqbldseQzgw==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/middleware-signing": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/middleware-signing": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -832,41 +615,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/middleware-serde": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-			"integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-signing": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
-			"integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.378.0.tgz",
+			"integrity": "sha512-XnEQUg1wkbakDMEcwpaPq4U1qn+jdGVyPLvcvcecw09yJj0+SIG5h3xWhBYVUxm9zEJUhIYc1DnNL2V5YFeCoQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/signature-v4": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-middleware": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/signature-v4": "^2.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-middleware": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -874,38 +639,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/middleware-stack": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-			"integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
-			"integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.378.0.tgz",
+			"integrity": "sha512-gwMmJgfqFh0k/Tvb+agXcdbIp9pUmYRN868CfqpKiQ7UlN8DHNixuPYrdktLkUBoEvnxmZEKdt0EnkBCdBTIcw==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -913,214 +661,22 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/node-config-provider": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
-			"integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/node-http-handler": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.347.0.tgz",
-			"integrity": "sha512-eluPf3CeeEaPbETsPw7ee0Rb0FP79amu8vdLMrQmkrD+KP4owupUXOEI4drxWJgBSd+3PRowPWCDA8wUtraHKg==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/abort-controller": "3.347.0",
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/querystring-builder": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/property-provider": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
-			"integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/property-provider/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/protocol-http": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-			"integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/protocol-http/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/querystring-builder": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
-			"integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-uri-escape": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/querystring-parser": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-			"integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/service-error-classification": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
-			"integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
-			"optional": true,
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/shared-ini-file-loader": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
-			"integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/signature-v4": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
-			"integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/eventstream-codec": "3.347.0",
-				"@aws-sdk/is-array-buffer": "3.310.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-hex-encoding": "3.310.0",
-				"@aws-sdk/util-middleware": "3.347.0",
-				"@aws-sdk/util-uri-escape": "3.310.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/smithy-client": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-			"integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.347.0.tgz",
-			"integrity": "sha512-DZS9UWEy105zsaBJTgcvv1U+0jl7j1OzfMpnLf/lEYjEvx/4FqY2Ue/OZUACJorZgm/dWNqrhY17tZXtS/S3ew==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.378.0.tgz",
+			"integrity": "sha512-2J3XCwYcImKGSpv4YZ7wqt/H+P56/BAFAmZx/LqwZlkgg+arTGo76WbeM0CQCsgmKuS9xZEVlfH4z+d0H9aoyw==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-sso-oidc": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/client-sso-oidc": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1128,17 +684,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-			"integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.378.0.tgz",
+			"integrity": "sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==",
 			"optional": true,
 			"dependencies": {
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1146,168 +703,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/types/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/url-parser": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-			"integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/querystring-parser": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			}
-		},
-		"node_modules/@aws-sdk/url-parser/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-base64": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-			"integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/util-buffer-from": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-base64/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-body-length-browser": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-			"integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.5.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-body-length-browser/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-body-length-node": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-			"integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-buffer-from": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-			"integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/is-array-buffer": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-config-provider": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-			"integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-defaults-mode-browser": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
-			"integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"bowser": "^2.11.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-defaults-mode-node": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
-			"integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/credential-provider-imds": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
-			"integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.378.0.tgz",
+			"integrity": "sha512-NU5C2l2xAXxpyB5nT0fIhahLPlJoJdzHWw4uC53KH9b4PrjHtgvgCN8beIsD3QxyfgeoM4A5J9Auo6WurfRnLw==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1315,27 +722,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-hex-encoding": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-			"integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
@@ -1351,91 +740,38 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-middleware": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-			"integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-retry": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
-			"integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/service-error-classification": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-retry/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-uri-escape": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-			"integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
-			"integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz",
+			"integrity": "sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/types": "^2.0.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
-			"integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz",
+			"integrity": "sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1451,23 +787,10 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
-		},
-		"node_modules/@aws-sdk/util-utf8": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-			"integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-			"optional": true,
-			"dependencies": {
-				"@aws-sdk/util-buffer-from": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
 		},
 		"node_modules/@aws-sdk/util-utf8-browser": {
 			"version": "3.259.0",
@@ -1479,15 +802,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"optional": true
-		},
-		"node_modules/@aws-sdk/util-utf8/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@babel/cli": {
@@ -3689,13 +3006,341 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@smithy/protocol-http": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-			"integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+		"node_modules/@smithy/abort-controller": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
+			"integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^1.0.0",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/abort-controller/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/config-resolver": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.1.tgz",
+			"integrity": "sha512-l83Pm7hV+8CBQOCmBRopWDtF+CURUJol7NsuPYvimiDhkC2F8Ba9T1imSFE+pD1UIJ9jlsDPAnZfPJT5cjnuEw==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-config-provider": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/config-resolver/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.1.tgz",
+			"integrity": "sha512-8VxriuRINNEfVZjEFKBY75y9ZWAx73DZ5K/u+3LmB6r8WR2h3NaFxFKMlwlq0uzNdGhD1ouKBn9XWEGYHKiPLw==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/property-provider": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.1.tgz",
+			"integrity": "sha512-/IiNB7gQM2y2ZC/GAWOWDa8+iXfhr1g9Xe5979cQEOdCWDISvrAiv18cn3OtIQUhbYOR3gm7QtCpkq1to2takQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-crypto/crc32": "3.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-hex-encoding": "^2.0.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.1.tgz",
+			"integrity": "sha512-/SoU/ClazgcdOxgE4zA7RX8euiELwpsrKCSvulVQvu9zpmqJRyEJn8ZTWYFV17/eHOBdHTs9kqodhNhsNT+cUw==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/querystring-builder": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-base64": "^2.0.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.1.tgz",
+			"integrity": "sha512-oTKYimQdF4psX54ZonpcIE+MXjMUWFxLCNosjPkJPFQ9whRX0K/PFX/+JZGRQh3zO9RlEOEUIbhy9NO+Wha6hw==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-node/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.1.tgz",
+			"integrity": "sha512-2q/Eb0AE662zwyMV+z+TL7deBwcHCgaZZGc0RItamBE8kak3MzCi/EZCNoFWoBfxgQ4jfR12wm8KKsSXhJzJtQ==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+			"integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.1.tgz",
+			"integrity": "sha512-IZhRSk5GkVBcrKaqPXddBS2uKhaqwBgaSgbBb1OJyGsKe7SxRFbclWS0LqOR9fKUkDl+3lL8E2ffpo6EQg0igw==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.1.tgz",
+			"integrity": "sha512-uz/KI1MBd9WHrrkVFZO4L4Wyv24raf0oR4EsOYEeG5jPJO5U+C7MZGLcMxX8gWERDn1sycBDqmGv8fjUMLxT6w==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-middleware": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.1.tgz",
+			"integrity": "sha512-NKHF4i0gjSyjO6C0ZyjEpNqzGgIu7s8HOK6oT/1Jqws2Q1GynR1xV8XTUs1gKXeaNRzbzKQRewHHmfPwZjOtHA==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/service-error-classification": "^2.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/util-retry": "^2.0.0",
+				"tslib": "^2.5.0",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/middleware-retry/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"optional": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.1.tgz",
+			"integrity": "sha512-uKxPaC6ItH9ZXdpdqNtf8sda7GcU4SPMp0tomq/5lUg9oiMa/Q7+kD35MUrpKaX3IVXVrwEtkjCU9dogZ/RAUA==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-serde/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
+			"integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.1.tgz",
+			"integrity": "sha512-Zoel4CPkKRTQ2XxmozZUfqBYqjPKL53/SvTDhJHj+VBSiJy6MXRav1iDCyFPS92t40Uh+Yi+Km5Ch3hQ+c/zSA==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/property-provider": "^2.0.1",
+				"@smithy/shared-ini-file-loader": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.1.tgz",
+			"integrity": "sha512-Zv3fxk3p9tsmPT2CKMsbuwbbxnq2gzLDIulxv+yI6aE+02WPYorObbbe9gh7SW3weadMODL1vTfOoJ9yFypDzg==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/abort-controller": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/querystring-builder": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.1.tgz",
+			"integrity": "sha512-pmJRyY9SF6sutWIktIhe+bUdSQDxv/qZ4mYr3/u+u45riTPN7nmRxPo+e4sjWVoM0caKFjRSlj3tf5teRFy0Vg==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.1.tgz",
+			"integrity": "sha512-mrkMAp0wtaDEIkgRObWYxI1Kun1tm6Iu6rK+X4utb6Ah7Uc3Kk4VIWwK/rBHdYGReiLIrxFCB1rq4a2gyZnSgg==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -3703,15 +3348,128 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.1.tgz",
+			"integrity": "sha512-bp+93WFzx1FojVEIeFPtG0A1pKsFdCUcZvVdZdRlmNooOUrz9Mm9bneRd8hDwAQ37pxiZkCOxopSXXRQN10mYw==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-uri-escape": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.1.tgz",
+			"integrity": "sha512-h+e7k1z+IvI2sSbUBG9Aq46JsgLl4UqIUl6aigAlRBj+P6ocNXpM6Yn1vMBw5ijtXeZbYpd1YvCxwDgdw3jhmg==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
+			"integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
+			"optional": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.1.tgz",
+			"integrity": "sha512-a463YiZrPGvM+F336rIF8pLfQsHAdCRAn/BiI/EWzg5xLoxbC7GSxIgliDDXrOu0z8gT3nhVsif85eU6jyct3A==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.1.tgz",
+			"integrity": "sha512-jztv5Mirca42ilxmMDjzLdXcoAmRhZskGafGL49sRo5u7swEZcToEFrq6vtX5YMbSyTVrE9Teog5EFexY5Ff2Q==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/eventstream-codec": "^2.0.1",
+				"@smithy/is-array-buffer": "^2.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-hex-encoding": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/util-uri-escape": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.1.tgz",
+			"integrity": "sha512-LHC5m6tYpEu1iNbONfvMbwtErboyTZJfEIPoD78Ei5MVr36vZQCaCla5mvo36+q/a2NAk2//fA5Rx3I1Kf7+lQ==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-stream": "^2.0.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@smithy/types": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-			"integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.0.2.tgz",
+			"integrity": "sha512-wcymEjIXQ9+NEfE5Yt5TInAqe1o4n+Nh+rh00AwoazppmUt8tdo6URhc5gkDcOYrcvlDVAZE7uG69nDpEGUKxw==",
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.5.0"
@@ -3721,9 +3479,276 @@
 			}
 		},
 		"node_modules/@smithy/types/node_modules/tslib": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/url-parser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.1.tgz",
+			"integrity": "sha512-NpHVOAwddo+OyyIoujDL9zGL96piHWrTNXqltWmBvlUoWgt1HPyBuKs6oHjioyFnNZXUqveTOkEEq0U5w6Uv8A==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/querystring-parser": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/url-parser/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
+			"integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-base64/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-body-length-browser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+			"integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-body-length-node": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
+			"integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-node/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+			"integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+			"integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-config-provider/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.1.tgz",
+			"integrity": "sha512-w72Qwsb+IaEYEFtYICn0Do42eFju78hTaBzzJfT107lFOPdbjWjKnFutV+6GL/nZd5HWXY7ccAKka++C3NrjHw==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/property-provider": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.1.tgz",
+			"integrity": "sha512-dNF45caelEBambo0SgkzQ0v76m4YM+aFKZNTtSafy7P5dVF8TbjZuR2UX1A5gJABD9XK6lzN+v/9Yfzj/EDgGg==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/credential-provider-imds": "^2.0.1",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/property-provider": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-hex-encoding": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+			"integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-middleware": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
+			"integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-middleware/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-retry": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
+			"integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/service-error-classification": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-retry/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.1.tgz",
+			"integrity": "sha512-2a0IOtwIKC46EEo7E7cxDN8u2jwOiYYJqcFKA6rd5rdXqKakHT2Gc+AqHWngr0IEHUfW92zX12wRQKwyoqZf2Q==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-hex-encoding": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-stream/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+			"integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+			"optional": true
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+			"integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8/node_modules/tslib": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+			"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 			"optional": true
 		},
 		"node_modules/@types/json-schema": {
@@ -5452,9 +5477,9 @@
 			"dev": true
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-			"integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+			"integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
 			"funding": [
 				{
 					"type": "paypal",
@@ -8615,438 +8640,387 @@
 				"tslib": "^1.11.1"
 			}
 		},
-		"@aws-sdk/abort-controller": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
-			"integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
 		"@aws-sdk/client-cognito-identity": {
-			"version": "3.347.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.347.1.tgz",
-			"integrity": "sha512-E7hyfLORHmGFXBiN+7/8cg6h6G4b2e7mRaqdMWkAcWAalrNGrxeeNTm17BdOLpxKBfT5u7II9+1fjDOG4LLecQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.378.0.tgz",
+			"integrity": "sha512-uN2qQaVwYigo0aDe1KhyanXYq6VyCfSK5swNopO/BjTEYvf0S65MR8BNEm8favBbC9eVGSVs3pH00WBWN8KxDw==",
 			"optional": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/client-sts": "3.347.1",
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/credential-provider-node": "3.347.0",
-				"@aws-sdk/fetch-http-handler": "3.347.0",
-				"@aws-sdk/hash-node": "3.347.0",
-				"@aws-sdk/invalid-dependency": "3.347.0",
-				"@aws-sdk/middleware-content-length": "3.347.0",
-				"@aws-sdk/middleware-endpoint": "3.347.0",
-				"@aws-sdk/middleware-host-header": "3.347.0",
-				"@aws-sdk/middleware-logger": "3.347.0",
-				"@aws-sdk/middleware-recursion-detection": "3.347.0",
-				"@aws-sdk/middleware-retry": "3.347.0",
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/middleware-signing": "3.347.0",
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/middleware-user-agent": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/node-http-handler": "3.347.0",
-				"@aws-sdk/smithy-client": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"@aws-sdk/util-body-length-browser": "3.310.0",
-				"@aws-sdk/util-body-length-node": "3.310.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.347.0",
-				"@aws-sdk/util-defaults-mode-node": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"@aws-sdk/util-user-agent-browser": "3.347.0",
-				"@aws-sdk/util-user-agent-node": "3.347.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"@smithy/protocol-http": "^1.0.1",
-				"@smithy/types": "^1.0.0",
+				"@aws-sdk/client-sts": "3.378.0",
+				"@aws-sdk/credential-provider-node": "3.378.0",
+				"@aws-sdk/middleware-host-header": "3.378.0",
+				"@aws-sdk/middleware-logger": "3.378.0",
+				"@aws-sdk/middleware-recursion-detection": "3.378.0",
+				"@aws-sdk/middleware-signing": "3.378.0",
+				"@aws-sdk/middleware-user-agent": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@aws-sdk/util-user-agent-browser": "3.378.0",
+				"@aws-sdk/util-user-agent-node": "3.378.0",
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/hash-node": "^2.0.1",
+				"@smithy/invalid-dependency": "^2.0.1",
+				"@smithy/middleware-content-length": "^2.0.1",
+				"@smithy/middleware-endpoint": "^2.0.1",
+				"@smithy/middleware-retry": "^2.0.1",
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/smithy-client": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.0.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.1",
+				"@smithy/util-defaults-mode-node": "^2.0.1",
+				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/client-sso": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.347.0.tgz",
-			"integrity": "sha512-AZehWCNLUXTrDavsZYRi7d84Uef20ppYJ2FY0KxqrKB3lx89mO29SfSJSC4woeW5+6ooBokq8HtKxw5ImPfRhA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.378.0.tgz",
+			"integrity": "sha512-xQ2myljd4T0W46WQVHnT61PLiIoGqcIJA6euClvSQndKqXt8fnJP6/kn2r+APIsjey823pjkEP4mZq8gYDiOOw==",
 			"optional": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/fetch-http-handler": "3.347.0",
-				"@aws-sdk/hash-node": "3.347.0",
-				"@aws-sdk/invalid-dependency": "3.347.0",
-				"@aws-sdk/middleware-content-length": "3.347.0",
-				"@aws-sdk/middleware-endpoint": "3.347.0",
-				"@aws-sdk/middleware-host-header": "3.347.0",
-				"@aws-sdk/middleware-logger": "3.347.0",
-				"@aws-sdk/middleware-recursion-detection": "3.347.0",
-				"@aws-sdk/middleware-retry": "3.347.0",
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/middleware-user-agent": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/node-http-handler": "3.347.0",
-				"@aws-sdk/smithy-client": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"@aws-sdk/util-body-length-browser": "3.310.0",
-				"@aws-sdk/util-body-length-node": "3.310.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.347.0",
-				"@aws-sdk/util-defaults-mode-node": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"@aws-sdk/util-user-agent-browser": "3.347.0",
-				"@aws-sdk/util-user-agent-node": "3.347.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"@smithy/protocol-http": "^1.0.1",
-				"@smithy/types": "^1.0.0",
+				"@aws-sdk/middleware-host-header": "3.378.0",
+				"@aws-sdk/middleware-logger": "3.378.0",
+				"@aws-sdk/middleware-recursion-detection": "3.378.0",
+				"@aws-sdk/middleware-user-agent": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@aws-sdk/util-user-agent-browser": "3.378.0",
+				"@aws-sdk/util-user-agent-node": "3.378.0",
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/hash-node": "^2.0.1",
+				"@smithy/invalid-dependency": "^2.0.1",
+				"@smithy/middleware-content-length": "^2.0.1",
+				"@smithy/middleware-endpoint": "^2.0.1",
+				"@smithy/middleware-retry": "^2.0.1",
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/smithy-client": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.0.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.1",
+				"@smithy/util-defaults-mode-node": "^2.0.1",
+				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/client-sso-oidc": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.347.0.tgz",
-			"integrity": "sha512-IBxRfPqb8f9FqpmDbzcRDfoiasj/Y47C4Gj+j3kA5T1XWyGwbDI9QnPW/rnkZTWxLUUG1LSbBNwbPD6TLoff8A==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.378.0.tgz",
+			"integrity": "sha512-+IcXH/W/TVzE0lMHuACgARgM/WxVbujGJzYUmDwj4E3uXjhTrRz69aeDk5z2EUggxKON9NOzHGZpm06VoS8uPA==",
 			"optional": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/fetch-http-handler": "3.347.0",
-				"@aws-sdk/hash-node": "3.347.0",
-				"@aws-sdk/invalid-dependency": "3.347.0",
-				"@aws-sdk/middleware-content-length": "3.347.0",
-				"@aws-sdk/middleware-endpoint": "3.347.0",
-				"@aws-sdk/middleware-host-header": "3.347.0",
-				"@aws-sdk/middleware-logger": "3.347.0",
-				"@aws-sdk/middleware-recursion-detection": "3.347.0",
-				"@aws-sdk/middleware-retry": "3.347.0",
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/middleware-user-agent": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/node-http-handler": "3.347.0",
-				"@aws-sdk/smithy-client": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"@aws-sdk/util-body-length-browser": "3.310.0",
-				"@aws-sdk/util-body-length-node": "3.310.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.347.0",
-				"@aws-sdk/util-defaults-mode-node": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"@aws-sdk/util-user-agent-browser": "3.347.0",
-				"@aws-sdk/util-user-agent-node": "3.347.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"@smithy/protocol-http": "^1.0.1",
-				"@smithy/types": "^1.0.0",
+				"@aws-sdk/middleware-host-header": "3.378.0",
+				"@aws-sdk/middleware-logger": "3.378.0",
+				"@aws-sdk/middleware-recursion-detection": "3.378.0",
+				"@aws-sdk/middleware-user-agent": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@aws-sdk/util-user-agent-browser": "3.378.0",
+				"@aws-sdk/util-user-agent-node": "3.378.0",
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/hash-node": "^2.0.1",
+				"@smithy/invalid-dependency": "^2.0.1",
+				"@smithy/middleware-content-length": "^2.0.1",
+				"@smithy/middleware-endpoint": "^2.0.1",
+				"@smithy/middleware-retry": "^2.0.1",
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/smithy-client": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.0.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.1",
+				"@smithy/util-defaults-mode-node": "^2.0.1",
+				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/client-sts": {
-			"version": "3.347.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.347.1.tgz",
-			"integrity": "sha512-i7vomVsbZcGD2pzOuEl0RS7yCtFcT6CVfSP1wZLwgcjAssUKTLHi65I/uSAUF0KituChw31aXlxh7EGq1uDqaA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.378.0.tgz",
+			"integrity": "sha512-u7y1I5BVjKEDK6ybA4c5smkbuoSFTBQqYX9qbCFYRErIA3qCICZB3duApcVRpdypKBzwYxUkLT/qKj4s9QTvrQ==",
 			"optional": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/credential-provider-node": "3.347.0",
-				"@aws-sdk/fetch-http-handler": "3.347.0",
-				"@aws-sdk/hash-node": "3.347.0",
-				"@aws-sdk/invalid-dependency": "3.347.0",
-				"@aws-sdk/middleware-content-length": "3.347.0",
-				"@aws-sdk/middleware-endpoint": "3.347.0",
-				"@aws-sdk/middleware-host-header": "3.347.0",
-				"@aws-sdk/middleware-logger": "3.347.0",
-				"@aws-sdk/middleware-recursion-detection": "3.347.0",
-				"@aws-sdk/middleware-retry": "3.347.0",
-				"@aws-sdk/middleware-sdk-sts": "3.347.0",
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/middleware-signing": "3.347.0",
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/middleware-user-agent": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/node-http-handler": "3.347.0",
-				"@aws-sdk/smithy-client": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"@aws-sdk/util-body-length-browser": "3.310.0",
-				"@aws-sdk/util-body-length-node": "3.310.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.347.0",
-				"@aws-sdk/util-defaults-mode-node": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"@aws-sdk/util-user-agent-browser": "3.347.0",
-				"@aws-sdk/util-user-agent-node": "3.347.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"@smithy/protocol-http": "^1.0.1",
-				"@smithy/types": "^1.0.0",
-				"fast-xml-parser": "4.2.4",
+				"@aws-sdk/credential-provider-node": "3.378.0",
+				"@aws-sdk/middleware-host-header": "3.378.0",
+				"@aws-sdk/middleware-logger": "3.378.0",
+				"@aws-sdk/middleware-recursion-detection": "3.378.0",
+				"@aws-sdk/middleware-sdk-sts": "3.378.0",
+				"@aws-sdk/middleware-signing": "3.378.0",
+				"@aws-sdk/middleware-user-agent": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@aws-sdk/util-user-agent-browser": "3.378.0",
+				"@aws-sdk/util-user-agent-node": "3.378.0",
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/hash-node": "^2.0.1",
+				"@smithy/invalid-dependency": "^2.0.1",
+				"@smithy/middleware-content-length": "^2.0.1",
+				"@smithy/middleware-endpoint": "^2.0.1",
+				"@smithy/middleware-retry": "^2.0.1",
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/smithy-client": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.0.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.1",
+				"@smithy/util-defaults-mode-node": "^2.0.1",
+				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"fast-xml-parser": "4.2.5",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/config-resolver": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
-			"integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-config-provider": "3.310.0",
-				"@aws-sdk/util-middleware": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.347.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.347.1.tgz",
-			"integrity": "sha512-7UQmpX5Xe4OPUgVtMK4+g5yMlYTmlpbYWbJG0RnyXtxLBG2OP4iyc8LGBq9AVY/ljTYGv+LSdVorldvERHUDCA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.378.0.tgz",
+			"integrity": "sha512-UVOJH4QC/LHNkwkE7ZlOEYqyCpDL87RKM8h3hZ98Rabj2UXZ2rH7bgHJBa1fFuokHnOM5Gf3LJvgLw38FMvvwA==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/client-cognito-identity": "3.347.1",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/client-cognito-identity": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-env": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
-			"integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz",
+			"integrity": "sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/credential-provider-imds": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
-			"integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-ini": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.347.0.tgz",
-			"integrity": "sha512-84TNF34ryabmVbILOq7f+/Jy8tJaskvHdax3X90qxFtXRU11kX0bf5NYL616KT0epR0VGpy50ThfIqvBwxeJfQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.378.0.tgz",
+			"integrity": "sha512-R34ELLCBTb+QkmWCaukNkT4vGeAipcL2wFN7Q2/WVSnJnRPPZSxzDK5rr78TiOPhRBu1k+aLDRNfslTZDknIIQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.347.0",
-				"@aws-sdk/credential-provider-imds": "3.347.0",
-				"@aws-sdk/credential-provider-process": "3.347.0",
-				"@aws-sdk/credential-provider-sso": "3.347.0",
-				"@aws-sdk/credential-provider-web-identity": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/credential-provider-env": "3.378.0",
+				"@aws-sdk/credential-provider-process": "3.378.0",
+				"@aws-sdk/credential-provider-sso": "3.378.0",
+				"@aws-sdk/credential-provider-web-identity": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/credential-provider-imds": "^2.0.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-node": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.347.0.tgz",
-			"integrity": "sha512-ds2uxE0krl94RdQ7bstwafUXdlMeEOPgedhaheVVlj8kH+XqlZdwUUaUv1uoEI9iBzuSjKftUkIHo0xsTiwtaw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.378.0.tgz",
+			"integrity": "sha512-vULsOsmcqSD+Prp/yl/o1gvQAKd2oHuqI8snh4G0RAkEvoyb7vx2l0ShCoXOVY/wM9PQH8nxBHmVbiAQfSndNg==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.347.0",
-				"@aws-sdk/credential-provider-imds": "3.347.0",
-				"@aws-sdk/credential-provider-ini": "3.347.0",
-				"@aws-sdk/credential-provider-process": "3.347.0",
-				"@aws-sdk/credential-provider-sso": "3.347.0",
-				"@aws-sdk/credential-provider-web-identity": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/credential-provider-env": "3.378.0",
+				"@aws-sdk/credential-provider-ini": "3.378.0",
+				"@aws-sdk/credential-provider-process": "3.378.0",
+				"@aws-sdk/credential-provider-sso": "3.378.0",
+				"@aws-sdk/credential-provider-web-identity": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/credential-provider-imds": "^2.0.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-process": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
-			"integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz",
+			"integrity": "sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-sso": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.347.0.tgz",
-			"integrity": "sha512-M1d7EnUaJbSNCmNalEbINmtFkc9wJufx7UhKtEeFwSq9KEzOMroH1MEOeiqIw9f/zE8NI/iPkVeEhw123vmBrQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.378.0.tgz",
+			"integrity": "sha512-lDPo/audYE/oERAef/VnHMe8THPCauH3Yu3DQYzCs+EWr1sIzp8vklWdMVQQI8cUlcLyYf4Dv9t8c+eJFZvrgw==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/client-sso": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/token-providers": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/client-sso": "3.378.0",
+				"@aws-sdk/token-providers": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/credential-provider-web-identity": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
-			"integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz",
+			"integrity": "sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/credential-providers": {
-			"version": "3.347.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.347.1.tgz",
-			"integrity": "sha512-2P7krq9w6egQnLxjU7IPp/Q4W8svs/NdWUKe1m17NVscop4GEAo9p26y2Ku23Jlw/lnmIpu8qHTEX+5+XEVSXg==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.378.0.tgz",
+			"integrity": "sha512-AP1/0u70z2EjU2tAHy4aKFGndaPFh4hl1bfGxL+h9xfDujyGYV0k//86BUjNw2yfCv5966jhYXi9nxIFG/05fw==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/client-cognito-identity": "3.347.1",
-				"@aws-sdk/client-sso": "3.347.0",
-				"@aws-sdk/client-sts": "3.347.1",
-				"@aws-sdk/credential-provider-cognito-identity": "3.347.1",
-				"@aws-sdk/credential-provider-env": "3.347.0",
-				"@aws-sdk/credential-provider-imds": "3.347.0",
-				"@aws-sdk/credential-provider-ini": "3.347.0",
-				"@aws-sdk/credential-provider-node": "3.347.0",
-				"@aws-sdk/credential-provider-process": "3.347.0",
-				"@aws-sdk/credential-provider-sso": "3.347.0",
-				"@aws-sdk/credential-provider-web-identity": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/client-cognito-identity": "3.378.0",
+				"@aws-sdk/client-sso": "3.378.0",
+				"@aws-sdk/client-sts": "3.378.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.378.0",
+				"@aws-sdk/credential-provider-env": "3.378.0",
+				"@aws-sdk/credential-provider-ini": "3.378.0",
+				"@aws-sdk/credential-provider-node": "3.378.0",
+				"@aws-sdk/credential-provider-process": "3.378.0",
+				"@aws-sdk/credential-provider-sso": "3.378.0",
+				"@aws-sdk/credential-provider-web-identity": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/credential-provider-imds": "^2.0.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
@@ -9058,721 +9032,183 @@
 				}
 			}
 		},
-		"@aws-sdk/eventstream-codec": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
-			"integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
-			"optional": true,
-			"requires": {
-				"@aws-crypto/crc32": "3.0.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-hex-encoding": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/fetch-http-handler": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
-			"integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/querystring-builder": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-base64": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/hash-node": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
-			"integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-buffer-from": "3.310.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/invalid-dependency": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
-			"integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/is-array-buffer": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-			"integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-			"optional": true,
-			"requires": {
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/middleware-content-length": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
-			"integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/middleware-endpoint": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-			"integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/middleware-serde": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/url-parser": "3.347.0",
-				"@aws-sdk/util-middleware": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
 		"@aws-sdk/middleware-host-header": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
-			"integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.378.0.tgz",
+			"integrity": "sha512-zzZZ8U3MxTgSW/bpr5wNbDuGUc/lPtB9c07bD/+F81KuGCOiPIl4PA4EyMI3tftPM9DbbcFX5ZwKi9vlZ4BWcw==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/middleware-logger": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
-			"integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz",
+			"integrity": "sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/middleware-recursion-detection": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
-			"integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz",
+			"integrity": "sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/middleware-retry": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
-			"integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/service-error-classification": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-middleware": "3.347.0",
-				"@aws-sdk/util-retry": "3.347.0",
-				"tslib": "^2.5.0",
-				"uuid": "^8.3.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				},
-				"uuid": {
-					"version": "8.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/middleware-sdk-sts": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
-			"integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.378.0.tgz",
+			"integrity": "sha512-uOoE4mvlJnR7NGIbCXQA3nI4qjWHfEETX4WzamjCQBTmoXBUlSU0hCRKvG5VHSpwI3XOu7dke9fFqbldseQzgw==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/middleware-signing": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/middleware-signing": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/middleware-serde": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-			"integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/middleware-signing": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
-			"integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.378.0.tgz",
+			"integrity": "sha512-XnEQUg1wkbakDMEcwpaPq4U1qn+jdGVyPLvcvcecw09yJj0+SIG5h3xWhBYVUxm9zEJUhIYc1DnNL2V5YFeCoQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/signature-v4": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-middleware": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/signature-v4": "^2.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-middleware": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/middleware-stack": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-			"integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-			"optional": true,
-			"requires": {
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/middleware-user-agent": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
-			"integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.378.0.tgz",
+			"integrity": "sha512-gwMmJgfqFh0k/Tvb+agXcdbIp9pUmYRN868CfqpKiQ7UlN8DHNixuPYrdktLkUBoEvnxmZEKdt0EnkBCdBTIcw==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-endpoints": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/util-endpoints": "3.378.0",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/node-config-provider": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
-			"integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/node-http-handler": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.347.0.tgz",
-			"integrity": "sha512-eluPf3CeeEaPbETsPw7ee0Rb0FP79amu8vdLMrQmkrD+KP4owupUXOEI4drxWJgBSd+3PRowPWCDA8wUtraHKg==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/abort-controller": "3.347.0",
-				"@aws-sdk/protocol-http": "3.347.0",
-				"@aws-sdk/querystring-builder": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/property-provider": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
-			"integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/protocol-http": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-			"integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/querystring-builder": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
-			"integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-uri-escape": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/querystring-parser": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-			"integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/service-error-classification": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
-			"integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
-			"optional": true
-		},
-		"@aws-sdk/shared-ini-file-loader": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
-			"integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/signature-v4": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
-			"integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/eventstream-codec": "3.347.0",
-				"@aws-sdk/is-array-buffer": "3.310.0",
-				"@aws-sdk/types": "3.347.0",
-				"@aws-sdk/util-hex-encoding": "3.310.0",
-				"@aws-sdk/util-middleware": "3.347.0",
-				"@aws-sdk/util-uri-escape": "3.310.0",
-				"@aws-sdk/util-utf8": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/smithy-client": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-			"integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/middleware-stack": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/token-providers": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.347.0.tgz",
-			"integrity": "sha512-DZS9UWEy105zsaBJTgcvv1U+0jl7j1OzfMpnLf/lEYjEvx/4FqY2Ue/OZUACJorZgm/dWNqrhY17tZXtS/S3ew==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.378.0.tgz",
+			"integrity": "sha512-2J3XCwYcImKGSpv4YZ7wqt/H+P56/BAFAmZx/LqwZlkgg+arTGo76WbeM0CQCsgmKuS9xZEVlfH4z+d0H9aoyw==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/client-sso-oidc": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/shared-ini-file-loader": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/client-sso-oidc": "3.378.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/property-provider": "^2.0.0",
+				"@smithy/shared-ini-file-loader": "^2.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/types": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-			"integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.378.0.tgz",
+			"integrity": "sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==",
 			"optional": true,
 			"requires": {
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/url-parser": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-			"integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/querystring-parser": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-base64": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-			"integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/util-buffer-from": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-body-length-browser": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-			"integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-			"optional": true,
-			"requires": {
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-body-length-node": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-			"integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-			"optional": true,
-			"requires": {
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-buffer-from": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-			"integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/is-array-buffer": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-config-provider": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-			"integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-			"optional": true,
-			"requires": {
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-defaults-mode-browser": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
-			"integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"bowser": "^2.11.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-defaults-mode-node": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
-			"integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/config-resolver": "3.347.0",
-				"@aws-sdk/credential-provider-imds": "3.347.0",
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/property-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/util-endpoints": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
-			"integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.378.0.tgz",
+			"integrity": "sha512-NU5C2l2xAXxpyB5nT0fIhahLPlJoJdzHWw4uC53KH9b4PrjHtgvgCN8beIsD3QxyfgeoM4A5J9Auo6WurfRnLw==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-hex-encoding": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-			"integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-			"optional": true,
-			"requires": {
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
@@ -9787,117 +9223,49 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-middleware": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-			"integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-			"optional": true,
-			"requires": {
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-retry": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
-			"integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/service-error-classification": "3.347.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-uri-escape": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-			"integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-			"optional": true,
-			"requires": {
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/util-user-agent-browser": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
-			"integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz",
+			"integrity": "sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/types": "^2.0.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@aws-sdk/util-user-agent-node": {
-			"version": "3.347.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
-			"integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
+			"version": "3.378.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz",
+			"integrity": "sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/node-config-provider": "3.347.0",
-				"@aws-sdk/types": "3.347.0",
+				"@aws-sdk/types": "3.378.0",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-					"optional": true
-				}
-			}
-		},
-		"@aws-sdk/util-utf8": {
-			"version": "3.310.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-			"integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/util-buffer-from": "3.310.0",
-				"tslib": "^2.5.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
@@ -9912,9 +9280,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
@@ -11460,37 +10828,719 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@smithy/protocol-http": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-			"integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+		"@smithy/abort-controller": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
+			"integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^1.0.0",
+				"@smithy/types": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/config-resolver": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.1.tgz",
+			"integrity": "sha512-l83Pm7hV+8CBQOCmBRopWDtF+CURUJol7NsuPYvimiDhkC2F8Ba9T1imSFE+pD1UIJ9jlsDPAnZfPJT5cjnuEw==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-config-provider": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/credential-provider-imds": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.1.tgz",
+			"integrity": "sha512-8VxriuRINNEfVZjEFKBY75y9ZWAx73DZ5K/u+3LmB6r8WR2h3NaFxFKMlwlq0uzNdGhD1ouKBn9XWEGYHKiPLw==",
+			"optional": true,
+			"requires": {
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/property-provider": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/eventstream-codec": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.1.tgz",
+			"integrity": "sha512-/IiNB7gQM2y2ZC/GAWOWDa8+iXfhr1g9Xe5979cQEOdCWDISvrAiv18cn3OtIQUhbYOR3gm7QtCpkq1to2takQ==",
+			"optional": true,
+			"requires": {
+				"@aws-crypto/crc32": "3.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-hex-encoding": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/fetch-http-handler": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.1.tgz",
+			"integrity": "sha512-/SoU/ClazgcdOxgE4zA7RX8euiELwpsrKCSvulVQvu9zpmqJRyEJn8ZTWYFV17/eHOBdHTs9kqodhNhsNT+cUw==",
+			"optional": true,
+			"requires": {
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/querystring-builder": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-base64": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/hash-node": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.1.tgz",
+			"integrity": "sha512-oTKYimQdF4psX54ZonpcIE+MXjMUWFxLCNosjPkJPFQ9whRX0K/PFX/+JZGRQh3zO9RlEOEUIbhy9NO+Wha6hw==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/invalid-dependency": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.1.tgz",
+			"integrity": "sha512-2q/Eb0AE662zwyMV+z+TL7deBwcHCgaZZGc0RItamBE8kak3MzCi/EZCNoFWoBfxgQ4jfR12wm8KKsSXhJzJtQ==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/is-array-buffer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+			"integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/middleware-content-length": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.1.tgz",
+			"integrity": "sha512-IZhRSk5GkVBcrKaqPXddBS2uKhaqwBgaSgbBb1OJyGsKe7SxRFbclWS0LqOR9fKUkDl+3lL8E2ffpo6EQg0igw==",
+			"optional": true,
+			"requires": {
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/middleware-endpoint": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.1.tgz",
+			"integrity": "sha512-uz/KI1MBd9WHrrkVFZO4L4Wyv24raf0oR4EsOYEeG5jPJO5U+C7MZGLcMxX8gWERDn1sycBDqmGv8fjUMLxT6w==",
+			"optional": true,
+			"requires": {
+				"@smithy/middleware-serde": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/url-parser": "^2.0.1",
+				"@smithy/util-middleware": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/middleware-retry": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.1.tgz",
+			"integrity": "sha512-NKHF4i0gjSyjO6C0ZyjEpNqzGgIu7s8HOK6oT/1Jqws2Q1GynR1xV8XTUs1gKXeaNRzbzKQRewHHmfPwZjOtHA==",
+			"optional": true,
+			"requires": {
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/service-error-classification": "^2.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/util-retry": "^2.0.0",
+				"tslib": "^2.5.0",
+				"uuid": "^8.3.2"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/middleware-serde": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.1.tgz",
+			"integrity": "sha512-uKxPaC6ItH9ZXdpdqNtf8sda7GcU4SPMp0tomq/5lUg9oiMa/Q7+kD35MUrpKaX3IVXVrwEtkjCU9dogZ/RAUA==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/middleware-stack": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
+			"integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/node-config-provider": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.1.tgz",
+			"integrity": "sha512-Zoel4CPkKRTQ2XxmozZUfqBYqjPKL53/SvTDhJHj+VBSiJy6MXRav1iDCyFPS92t40Uh+Yi+Km5Ch3hQ+c/zSA==",
+			"optional": true,
+			"requires": {
+				"@smithy/property-provider": "^2.0.1",
+				"@smithy/shared-ini-file-loader": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/node-http-handler": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.1.tgz",
+			"integrity": "sha512-Zv3fxk3p9tsmPT2CKMsbuwbbxnq2gzLDIulxv+yI6aE+02WPYorObbbe9gh7SW3weadMODL1vTfOoJ9yFypDzg==",
+			"optional": true,
+			"requires": {
+				"@smithy/abort-controller": "^2.0.1",
+				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/querystring-builder": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/property-provider": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.1.tgz",
+			"integrity": "sha512-pmJRyY9SF6sutWIktIhe+bUdSQDxv/qZ4mYr3/u+u45riTPN7nmRxPo+e4sjWVoM0caKFjRSlj3tf5teRFy0Vg==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/protocol-http": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.1.tgz",
+			"integrity": "sha512-mrkMAp0wtaDEIkgRObWYxI1Kun1tm6Iu6rK+X4utb6Ah7Uc3Kk4VIWwK/rBHdYGReiLIrxFCB1rq4a2gyZnSgg==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/querystring-builder": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.1.tgz",
+			"integrity": "sha512-bp+93WFzx1FojVEIeFPtG0A1pKsFdCUcZvVdZdRlmNooOUrz9Mm9bneRd8hDwAQ37pxiZkCOxopSXXRQN10mYw==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-uri-escape": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/querystring-parser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.1.tgz",
+			"integrity": "sha512-h+e7k1z+IvI2sSbUBG9Aq46JsgLl4UqIUl6aigAlRBj+P6ocNXpM6Yn1vMBw5ijtXeZbYpd1YvCxwDgdw3jhmg==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/service-error-classification": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
+			"integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
+			"optional": true
+		},
+		"@smithy/shared-ini-file-loader": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.1.tgz",
+			"integrity": "sha512-a463YiZrPGvM+F336rIF8pLfQsHAdCRAn/BiI/EWzg5xLoxbC7GSxIgliDDXrOu0z8gT3nhVsif85eU6jyct3A==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/signature-v4": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.1.tgz",
+			"integrity": "sha512-jztv5Mirca42ilxmMDjzLdXcoAmRhZskGafGL49sRo5u7swEZcToEFrq6vtX5YMbSyTVrE9Teog5EFexY5Ff2Q==",
+			"optional": true,
+			"requires": {
+				"@smithy/eventstream-codec": "^2.0.1",
+				"@smithy/is-array-buffer": "^2.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-hex-encoding": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/util-uri-escape": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/smithy-client": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.1.tgz",
+			"integrity": "sha512-LHC5m6tYpEu1iNbONfvMbwtErboyTZJfEIPoD78Ei5MVr36vZQCaCla5mvo36+q/a2NAk2//fA5Rx3I1Kf7+lQ==",
+			"optional": true,
+			"requires": {
+				"@smithy/middleware-stack": "^2.0.0",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-stream": "^2.0.1",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
 		},
 		"@smithy/types": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-			"integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.0.2.tgz",
+			"integrity": "sha512-wcymEjIXQ9+NEfE5Yt5TInAqe1o4n+Nh+rh00AwoazppmUt8tdo6URhc5gkDcOYrcvlDVAZE7uG69nDpEGUKxw==",
 			"optional": true,
 			"requires": {
 				"tslib": "^2.5.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.5.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-					"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/url-parser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.1.tgz",
+			"integrity": "sha512-NpHVOAwddo+OyyIoujDL9zGL96piHWrTNXqltWmBvlUoWgt1HPyBuKs6oHjioyFnNZXUqveTOkEEq0U5w6Uv8A==",
+			"optional": true,
+			"requires": {
+				"@smithy/querystring-parser": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-base64": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
+			"integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+			"optional": true,
+			"requires": {
+				"@smithy/util-buffer-from": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-body-length-browser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+			"integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-body-length-node": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
+			"integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-buffer-from": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+			"integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+			"optional": true,
+			"requires": {
+				"@smithy/is-array-buffer": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-config-provider": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+			"integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-defaults-mode-browser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.1.tgz",
+			"integrity": "sha512-w72Qwsb+IaEYEFtYICn0Do42eFju78hTaBzzJfT107lFOPdbjWjKnFutV+6GL/nZd5HWXY7ccAKka++C3NrjHw==",
+			"optional": true,
+			"requires": {
+				"@smithy/property-provider": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-defaults-mode-node": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.1.tgz",
+			"integrity": "sha512-dNF45caelEBambo0SgkzQ0v76m4YM+aFKZNTtSafy7P5dVF8TbjZuR2UX1A5gJABD9XK6lzN+v/9Yfzj/EDgGg==",
+			"optional": true,
+			"requires": {
+				"@smithy/config-resolver": "^2.0.1",
+				"@smithy/credential-provider-imds": "^2.0.1",
+				"@smithy/node-config-provider": "^2.0.1",
+				"@smithy/property-provider": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-hex-encoding": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+			"integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-middleware": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
+			"integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-retry": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
+			"integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+			"optional": true,
+			"requires": {
+				"@smithy/service-error-classification": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.1.tgz",
+			"integrity": "sha512-2a0IOtwIKC46EEo7E7cxDN8u2jwOiYYJqcFKA6rd5rdXqKakHT2Gc+AqHWngr0IEHUfW92zX12wRQKwyoqZf2Q==",
+			"optional": true,
+			"requires": {
+				"@smithy/fetch-http-handler": "^2.0.1",
+				"@smithy/node-http-handler": "^2.0.1",
+				"@smithy/types": "^2.0.2",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-hex-encoding": "^2.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-uri-escape": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+			"integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+					"optional": true
+				}
+			}
+		},
+		"@smithy/util-utf8": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+			"integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+			"optional": true,
+			"requires": {
+				"@smithy/util-buffer-from": "^2.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+					"integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
 					"optional": true
 				}
 			}
@@ -12722,9 +12772,9 @@
 			"dev": true
 		},
 		"fast-xml-parser": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-			"integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+			"integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
 			"optional": true,
 			"requires": {
 				"strnum": "^1.0.5"


### PR DESCRIPTION
Bumps [fast-xml-parser](https://github.com/NaturalIntelligence/fast-xml-parser) and [@aws-sdk/credential-providers](https://github.com/aws/aws-sdk-js-v3/tree/HEAD/packages/credential-providers). These dependencies needed to be updated together.

Updates `fast-xml-parser` from 4.2.4 to 4.2.5
- [Release notes](https://github.com/NaturalIntelligence/fast-xml-parser/releases)
- [Changelog](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md)
- [Commits](https://github.com/NaturalIntelligence/fast-xml-parser/compare/v4.2.4...v4.2.5)

Updates `@aws-sdk/credential-providers` from 3.347.1 to 3.378.0
- [Release notes](https://github.com/aws/aws-sdk-js-v3/releases)
- [Changelog](https://github.com/aws/aws-sdk-js-v3/blob/main/packages/credential-providers/CHANGELOG.md)
- [Commits](https://github.com/aws/aws-sdk-js-v3/commits/v3.378.0/packages/credential-providers)

---
updated-dependencies:
- dependency-name: fast-xml-parser dependency-type: indirect
- dependency-name: "@aws-sdk/credential-providers" dependency-type: indirect ...