### PR TITLE
Dependency update (#248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ https://rest.api.melinda-test.kansalliskirjasto.fi/apidoc/v1/bib/
 
 ## License and copyright
 
-Copyright (c) 2018-2023 **University Of Helsinki (The National Library Of Finland)**
+Copyright (c) 2018-2024 **University Of Helsinki (The National Library Of Finland)**
 
 This project's source code is licensed under the terms of **GNU Affero General Public License Version 3** or any later version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.3.6-alpha.2",
+	"version": "3.3.6-alpha.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.3.6-alpha.2",
+			"version": "3.3.6-alpha.3",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.23.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@natlibfi/marc-record-serializers": "^10.1.2",
 				"@natlibfi/melinda-backend-commons": "^2.2.6",
 				"@natlibfi/melinda-commons": "^13.0.12",
-				"@natlibfi/melinda-rest-api-commons": "^4.1.2-alpha.1",
+				"@natlibfi/melinda-rest-api-commons": "^4.1.3",
 				"@natlibfi/passport-melinda-aleph": "^2.0.4",
 				"@natlibfi/sru-client": "^6.0.8",
 				"body-parser": "^1.20.2",
@@ -2962,9 +2962,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "4.1.2-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.2-alpha.1.tgz",
-			"integrity": "sha512-N3MdSurZhwCQqMzsegJ4T05vdgTtlP2VDpQb+WQd07X0+xHjQnaLjZBl5S8TItOdVwT0uEmoaLSVzyIlIu9cPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.3.tgz",
+			"integrity": "sha512-fu1FjzdwUWbLVB7i1GsuIE5/LmYOPuNtuE9uId18rGG+roDAto+VzRCpK/iZd3UgYqMryaeSGFCroKJCIWldZA==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.1.0",
 				"@natlibfi/marc-record-serializers": "^10.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.3.5",
+	"version": "3.3.6-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.3.5",
+			"version": "3.3.6-alpha.2",
 			"license": "AGPL-3.0+",
 			"dependencies": {
-				"@babel/runtime": "^7.23.8",
+				"@babel/runtime": "^7.23.9",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
 				"@natlibfi/melinda-backend-commons": "^2.2.6",
-				"@natlibfi/melinda-commons": "^13.0.11",
-				"@natlibfi/melinda-rest-api-commons": "^4.1.1",
+				"@natlibfi/melinda-commons": "^13.0.12",
+				"@natlibfi/melinda-rest-api-commons": "^4.1.2-alpha.1",
 				"@natlibfi/passport-melinda-aleph": "^2.0.4",
 				"@natlibfi/sru-client": "^6.0.8",
 				"body-parser": "^1.20.2",
@@ -27,11 +27,11 @@
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.23.4",
-				"@babel/core": "^7.23.7",
-				"@babel/node": "^7.22.19",
-				"@babel/plugin-transform-runtime": "^7.23.7",
-				"@babel/preset-env": "^7.23.8",
+				"@babel/cli": "^7.23.9",
+				"@babel/core": "^7.23.9",
+				"@babel/node": "^7.23.9",
+				"@babel/plugin-transform-runtime": "^7.23.9",
+				"@babel/preset-env": "^7.23.9",
 				"@babel/register": "^7.23.7",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
 				"cross-env": "^7.0.3",
@@ -863,9 +863,9 @@
 			"optional": true
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.4.tgz",
-			"integrity": "sha512-j3luA9xGKCXVyCa5R7lJvOMM+Kc2JEnAEIgz2ggtjQ/j5YUVgfsg/WsG95bbsgq7YLHuiCOzMnoSasuY16qiCw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.9.tgz",
+			"integrity": "sha512-vB1UXmGDNEhcf1jNAHKT9IlYk1R+hehVTLFlCLHBi8gfuHQGP6uRjgXVYU0EVlI/qwAWpstqkBdf2aez3/z/5Q==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -912,20 +912,20 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
-			"integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
+			"integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.23.5",
 				"@babel/generator": "^7.23.6",
 				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.7",
-				"@babel/parser": "^7.23.6",
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.7",
-				"@babel/types": "^7.23.6",
+				"@babel/helpers": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@babel/template": "^7.23.9",
+				"@babel/traverse": "^7.23.9",
+				"@babel/types": "^7.23.9",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -941,9 +941,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.3.tgz",
-			"integrity": "sha512-9bTuNlyx7oSstodm1cR1bECj4fkiknsDa1YniISkJemMY3DGhJNYBECbe6QD/q54mp2J8VO66jW3/7uP//iFCw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.9.tgz",
+			"integrity": "sha512-xPndlO7qxiJbn0ATvfXQBjCS7qApc9xmKHArgI/FTEFxXas5dnjC/VqM37lfZun9dclRYcn+YQAr6uDFy0bB2g==",
 			"dev": true,
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -1012,9 +1012,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.7.tgz",
-			"integrity": "sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.9.tgz",
+			"integrity": "sha512-B2L9neXTIyPQoXDm+NtovPvG6VOLWnaXu3BIeVDWwdKFgG30oNa6CqVGiJPDWQwIAK49t9gnQI9c6K6RzabiKw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
@@ -1267,13 +1267,13 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
-			"integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
+			"integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
 			"dependencies": {
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.7",
-				"@babel/types": "^7.23.6"
+				"@babel/template": "^7.23.9",
+				"@babel/traverse": "^7.23.9",
+				"@babel/types": "^7.23.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1293,12 +1293,12 @@
 			}
 		},
 		"node_modules/@babel/node": {
-			"version": "7.22.19",
-			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.19.tgz",
-			"integrity": "sha512-VsKSO9aEHdO16NdtqkJfrXZ9Sxlna1BVnBbToWr1KGdI3cyIk6KqOoa8mWvpK280lJDOwJqxvnl994KmLhq1Yw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.23.9.tgz",
+			"integrity": "sha512-/d4ju/POwlGIJlZ+NqWH1qu61wt6ZlTZZZutrK2MOSdaH1JCh726nLw/GSvAjG+LTY6CO9SsB8uWcttnFKm6yg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/register": "^7.22.15",
+				"@babel/register": "^7.23.7",
 				"commander": "^4.0.1",
 				"core-js": "^3.30.2",
 				"node-environment-flags": "^1.0.5",
@@ -1316,9 +1316,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+			"integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1637,9 +1637,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz",
-			"integrity": "sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz",
+			"integrity": "sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -1995,9 +1995,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz",
-			"integrity": "sha512-ZxyKGTkF9xT9YJuKQRo19ewf3pXpopuYQd8cDXqNzc3mUNbOME0RKMoZxviQk74hwzfQsEe66dE92MaZbdHKNQ==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
+			"integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-hoist-variables": "^7.22.5",
@@ -2255,16 +2255,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.7.tgz",
-			"integrity": "sha512-fa0hnfmiXc9fq/weK34MUV0drz2pOL/vfKWvN7Qw127hiUPabFCUMgAbYWcchRzMJit4o5ARsK/s+5h0249pLw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.9.tgz",
+			"integrity": "sha512-A7clW3a0aSjm3ONU9o2HAILSegJCYlEZmOhmBRReVtIpY/Z/p7yIZ+wR41Z+UipwdGuqwtID/V/dOdZXjwi9gQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"babel-plugin-polyfill-corejs2": "^0.4.7",
-				"babel-plugin-polyfill-corejs3": "^0.8.7",
-				"babel-plugin-polyfill-regenerator": "^0.5.4",
+				"babel-plugin-polyfill-corejs2": "^0.4.8",
+				"babel-plugin-polyfill-corejs3": "^0.9.0",
+				"babel-plugin-polyfill-regenerator": "^0.5.5",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -2414,9 +2414,9 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.8",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.8.tgz",
-			"integrity": "sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
+			"integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.23.5",
@@ -2446,7 +2446,7 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.23.3",
-				"@babel/plugin-transform-async-generator-functions": "^7.23.7",
+				"@babel/plugin-transform-async-generator-functions": "^7.23.9",
 				"@babel/plugin-transform-async-to-generator": "^7.23.3",
 				"@babel/plugin-transform-block-scoped-functions": "^7.23.3",
 				"@babel/plugin-transform-block-scoping": "^7.23.4",
@@ -2468,7 +2468,7 @@
 				"@babel/plugin-transform-member-expression-literals": "^7.23.3",
 				"@babel/plugin-transform-modules-amd": "^7.23.3",
 				"@babel/plugin-transform-modules-commonjs": "^7.23.3",
-				"@babel/plugin-transform-modules-systemjs": "^7.23.3",
+				"@babel/plugin-transform-modules-systemjs": "^7.23.9",
 				"@babel/plugin-transform-modules-umd": "^7.23.3",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
 				"@babel/plugin-transform-new-target": "^7.23.3",
@@ -2494,9 +2494,9 @@
 				"@babel/plugin-transform-unicode-regex": "^7.23.3",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.7",
-				"babel-plugin-polyfill-corejs3": "^0.8.7",
-				"babel-plugin-polyfill-regenerator": "^0.5.4",
+				"babel-plugin-polyfill-corejs2": "^0.4.8",
+				"babel-plugin-polyfill-corejs3": "^0.9.0",
+				"babel-plugin-polyfill-regenerator": "^0.5.5",
 				"core-js-compat": "^3.31.0",
 				"semver": "^6.3.1"
 			},
@@ -2546,9 +2546,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.23.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
-			"integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+			"integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -2557,22 +2557,22 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+			"integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-			"integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+			"integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
 			"dependencies": {
 				"@babel/code-frame": "^7.23.5",
 				"@babel/generator": "^7.23.6",
@@ -2580,8 +2580,8 @@
 				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.6",
-				"@babel/types": "^7.23.6",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2590,9 +2590,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-			"integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+			"integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.23.4",
 				"@babel/helper-validator-identifier": "^7.22.20",
@@ -2886,26 +2886,26 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validate": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-8.0.5.tgz",
-			"integrity": "sha512-AUscqIZxJi/1ho6/fDTC22CcjP8PXZhHrBOYneb38Gwl3i2q8EGC29nMnVtvI/aF80nWFG0kfAm2xCCYbkgQBA==",
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-8.0.6.tgz",
+			"integrity": "sha512-wqMVNoWx82JAL3pS/xyoewvPtPnD02K7VnK+eQEhBW/N68/8uxnhXY663EoSyLwIEUwYH6qm+xk6hSUoPtZalA==",
 			"dependencies": {
-				"@babel/runtime": "^7.23.6",
-				"@natlibfi/marc-record": "^8.0.2"
+				"@babel/runtime": "^7.23.8",
+				"@natlibfi/marc-record": "^8.1.0"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "10.15.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.15.5.tgz",
-			"integrity": "sha512-brLT0G2xWI7Y9xQEyoBLJ9YwaXqXH6F9AbZaxi/oS6nMKk/Vp4JQfUtTrEY0v1IocvtsJV1DlBuF0zAVs5BaZA==",
+			"version": "10.16.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.16.0.tgz",
+			"integrity": "sha512-z7BnRVltqEiK6zu/fGHZdEFvKTZ8A04s9zXrmzX+qZjdPW2VLbiDXLaaSuErs8snnb2Uu7LAAoXkqaGn7kyixQ==",
 			"dependencies": {
 				"@babel/register": "^7.23.7",
 				"@natlibfi/issn-verify": "^1.0.3",
 				"@natlibfi/marc-record": "^8.1.0",
-				"@natlibfi/marc-record-validate": "^8.0.5",
+				"@natlibfi/marc-record-validate": "^8.0.6",
 				"cld3-asm": "^3.1.1",
 				"clone": "^2.1.2",
 				"debug": "^4.3.4",
@@ -2918,7 +2918,7 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@natlibfi/marc-record-validate": "^8.0.5"
+				"@natlibfi/marc-record-validate": "^8.0.6"
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
@@ -2943,11 +2943,11 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.11",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.11.tgz",
-			"integrity": "sha512-IQRpKfSMwfNcOldOnoyWGxAs8v6TPDNVUa/mOq3eh13aLtwQFG/uQIGWFJkGBiwIQcd+C12Y4mHFLqdQOkI8UA==",
+			"version": "13.0.12",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.12.tgz",
+			"integrity": "sha512-Vl+xr7dcZy+URYCEyWBm9pDJyJBoDzTSxHIb8CMCgMA6KI/3YrPkUkaL3Yz0hLWgdo8fUKDMRKErjTv8am9P7w==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^8.0.2",
+				"@natlibfi/marc-record": "^8.1.0",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
 				"@natlibfi/sru-client": "^6.0.8",
 				"debug": "^4.3.4",
@@ -2962,16 +2962,16 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.1.tgz",
-			"integrity": "sha512-fyjM5fzb6myAxKkAkmDhm/0yOcTKSyK9aZngijszNs4aG/LJYaMaxFOwsRaMoA2sckIKlWmMikpofhEwu2gHog==",
+			"version": "4.1.2-alpha.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.2-alpha.1.tgz",
+			"integrity": "sha512-N3MdSurZhwCQqMzsegJ4T05vdgTtlP2VDpQb+WQd07X0+xHjQnaLjZBl5S8TItOdVwT0uEmoaLSVzyIlIu9cPQ==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^8.0.2",
+				"@natlibfi/marc-record": "^8.1.0",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/marc-record-validate": "^8.0.4",
-				"@natlibfi/marc-record-validators-melinda": "^10.15.2",
-				"@natlibfi/melinda-backend-commons": "^2.2.5",
-				"@natlibfi/melinda-commons": "^13.0.10",
+				"@natlibfi/marc-record-validate": "^8.0.6",
+				"@natlibfi/marc-record-validators-melinda": "^10.16.0",
+				"@natlibfi/melinda-backend-commons": "^2.2.6",
+				"@natlibfi/melinda-commons": "^13.0.12",
 				"amqplib": "^0.10.3",
 				"debug": "^4.3.4",
 				"http-status": "^1.7.3",
@@ -3939,9 +3939,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.11.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
-			"integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
+			"version": "20.11.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.7.tgz",
+			"integrity": "sha512-GPmeN1C3XAyV5uybAf4cMLWT9fDWcmQhZVtMFu7OR32WjrqGG+Wnk2V1d0bmtUyE/Zy1QJ9BxyiTih9z8Oks8A==",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -4394,29 +4394,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz",
-			"integrity": "sha512-KyDvZYxAzkC0Aj2dAPyDzi2Ym15e5JKZSK+maI7NAwSqofvuFglbSsxE7wUOvTg9oFVnHMzVzBKcqEb4PJgtOA==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
+			"integrity": "sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.4",
-				"core-js-compat": "^3.33.1"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-			}
-		},
-		"node_modules/babel-plugin-polyfill-corejs3/node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
-			"integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.22.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"debug": "^4.1.1",
-				"lodash.debounce": "^4.0.8",
-				"resolve": "^1.14.2"
+				"@babel/helper-define-polyfill-provider": "^0.5.0",
+				"core-js-compat": "^3.34.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -5039,9 +5023,9 @@
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.645",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.645.tgz",
-			"integrity": "sha512-EeS1oQDCmnYsRDRy2zTeC336a/4LZ6WKqvSaM1jLocEk5ZuyszkQtCpsqvuvaIXGOUjwtvF6LTcS8WueibXvSw=="
+			"version": "1.4.647",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.647.tgz",
+			"integrity": "sha512-Z/fTNGwc45WrYQhPaEcz5tAJuZZ8G7S/DBnhS6Kgp4BxnS40Z/HqlJ0hHg3Z79IGVzuVartIlTcjw/cQbPLgOw=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -6519,10 +6503,17 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/ip": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+		"node_modules/ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
@@ -6998,9 +6989,9 @@
 			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
 		},
 		"node_modules/isbn3": {
-			"version": "1.1.44",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.44.tgz",
-			"integrity": "sha512-lHwBx85hTHPwtSHrieC+AG73doLOIpNbb6OEchh3v2MZrxKJ+HN24ksgparYjRRgNtzVxzuNQd8VBZMEBxcMBw==",
+			"version": "1.1.45",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.45.tgz",
+			"integrity": "sha512-9oD3yItVFRlYhm/K6RI2K6f+Dti0unzG74X9I7D+xVKMK3TbRl2PMvnWgK6scKnvk4t0BZFyNIznX4H45RrwzQ==",
 			"bin": {
 				"isbn": "bin/isbn",
 				"isbn-audit": "bin/isbn-audit",
@@ -7040,6 +7031,11 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
+		},
+		"node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
 		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
@@ -8477,15 +8473,15 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+			"integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
 			"dependencies": {
-				"ip": "^2.0.0",
+				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
-				"node": ">= 10.13.0",
+				"node": ">= 10.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},
@@ -8514,6 +8510,11 @@
 			"dependencies": {
 				"memory-pager": "^1.0.2"
 			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
 		},
 		"node_modules/stack-trace": {
 			"version": "0.0.10",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.3.6-alpha.2",
+	"version": "3.3.6-alpha.3",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "3.3.5",
+	"version": "3.3.6-alpha.2",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -30,11 +30,11 @@
 		"prod": "NODE_ENV=production npm run build && npm run start"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.23.8",
+		"@babel/runtime": "^7.23.9",
 		"@natlibfi/marc-record-serializers": "^10.1.2",
 		"@natlibfi/melinda-backend-commons": "^2.2.6",
-		"@natlibfi/melinda-commons": "^13.0.11",
-		"@natlibfi/melinda-rest-api-commons": "^4.1.1",
+		"@natlibfi/melinda-commons": "^13.0.12",
+		"@natlibfi/melinda-rest-api-commons": "^4.1.2-alpha.1",
 		"@natlibfi/passport-melinda-aleph": "^2.0.4",
 		"@natlibfi/sru-client": "^6.0.8",
 		"body-parser": "^1.20.2",
@@ -48,11 +48,11 @@
 		"uuid": "^9.0.1"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.23.4",
-		"@babel/core": "^7.23.7",
-		"@babel/node": "^7.22.19",
-		"@babel/plugin-transform-runtime": "^7.23.7",
-		"@babel/preset-env": "^7.23.8",
+		"@babel/cli": "^7.23.9",
+		"@babel/core": "^7.23.9",
+		"@babel/node": "^7.23.9",
+		"@babel/plugin-transform-runtime": "^7.23.9",
+		"@babel/preset-env": "^7.23.9",
 		"@babel/register": "^7.23.7",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
 		"cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"@natlibfi/marc-record-serializers": "^10.1.2",
 		"@natlibfi/melinda-backend-commons": "^2.2.6",
 		"@natlibfi/melinda-commons": "^13.0.12",
-		"@natlibfi/melinda-rest-api-commons": "^4.1.2-alpha.1",
+		"@natlibfi/melinda-rest-api-commons": "^4.1.3",
 		"@natlibfi/passport-melinda-aleph": "^2.0.4",
 		"@natlibfi/sru-client": "^6.0.8",
 		"body-parser": "^1.20.2",


### PR DESCRIPTION
* Bump the development-dependencies group with 5 updates (#247)

| Package | From | To |
| --- | --- | --- |
| [@babel/cli](https://github.com/babel/babel/tree/HEAD/packages/babel-cli) | `7.23.4` | `7.23.9` | | [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) | `7.23.7` | `7.23.9` | | [@babel/node](https://github.com/babel/babel/tree/HEAD/packages/babel-node) | `7.22.19` | `7.23.9` | | [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-runtime) | `7.23.7` | `7.23.9` | | [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env) | `7.23.8` | `7.23.9` |

* Bump the production-dependencies group with 2 updates (#246) Bumps the production-dependencies group with 2 updates: [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime) and [@natlibfi/melinda-commons](https://github.com/natlibfi/melinda-commons-js).

* Update copyright year

* Update deps

* 3.3.6-alpha.2