### PR TITLE
Dependency update (#293)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.3.10",
+	"version": "3.3.11-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.3.10",
+			"version": "3.3.11-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.25.0",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
 				"@natlibfi/melinda-backend-commons": "^2.3.1",
 				"@natlibfi/melinda-commons": "^13.0.16",
-				"@natlibfi/melinda-rest-api-commons": "^4.1.9",
+				"@natlibfi/melinda-rest-api-commons": "^4.1.10",
 				"@natlibfi/passport-melinda-aleph": "^2.0.4",
 				"@natlibfi/sru-client": "^6.0.14",
 				"body-parser": "^1.20.2",
@@ -981,9 +981,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
-			"integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+			"integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1036,11 +1036,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-			"integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+			"version": "7.25.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
+			"integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
 			"dependencies": {
-				"@babel/types": "^7.25.0",
+				"@babel/types": "^7.25.4",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
@@ -1090,9 +1090,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.0.tgz",
-			"integrity": "sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+			"integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
@@ -1100,7 +1100,7 @@
 				"@babel/helper-optimise-call-expression": "^7.24.7",
 				"@babel/helper-replace-supers": "^7.25.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-				"@babel/traverse": "^7.25.0",
+				"@babel/traverse": "^7.25.4",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1353,11 +1353,11 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.25.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-			"integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
+			"integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
 			"dependencies": {
-				"@babel/types": "^7.25.2"
+				"@babel/types": "^7.25.4"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1708,15 +1708,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.0.tgz",
-			"integrity": "sha512-uaIi2FdqzjpAMvVqvB51S42oC2JEVgh0LDsGfZVDysWE8LrJtQC2jvKmOqEYThKyB7bDEb7BP1GYWDm7tABA0Q==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.4.tgz",
+			"integrity": "sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/helper-remap-async-to-generator": "^7.25.0",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
-				"@babel/traverse": "^7.25.0"
+				"@babel/traverse": "^7.25.4"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1773,13 +1773,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
-			"integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.4.tgz",
+			"integrity": "sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-create-class-features-plugin": "^7.25.4",
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1806,16 +1806,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.0.tgz",
-			"integrity": "sha512-xyi6qjr/fYU304fiRwFbekzkqVJZ6A7hOjWZd+89FVcBqPV3S9Wuozz82xdpLspckeaafntbzglaW4pqpzvtSw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz",
+			"integrity": "sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-compilation-targets": "^7.24.8",
+				"@babel/helper-compilation-targets": "^7.25.2",
 				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/helper-replace-supers": "^7.25.0",
-				"@babel/traverse": "^7.25.0",
+				"@babel/traverse": "^7.25.4",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -2259,13 +2259,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz",
-			"integrity": "sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.4.tgz",
+			"integrity": "sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-create-class-features-plugin": "^7.25.4",
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2339,15 +2339,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.7.tgz",
-			"integrity": "sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.4.tgz",
+			"integrity": "sha512-8hsyG+KUYGY0coX6KUCDancA0Vw225KJ2HJO0yCNr1vq5r+lJTleDaJf0K7iOhjw4SWhu03TMBzYTJ9krmzULQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.8",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.1",
+				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"semver": "^6.3.1"
 			},
@@ -2482,13 +2482,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.7.tgz",
-			"integrity": "sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.4.tgz",
+			"integrity": "sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.2",
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2498,12 +2498,12 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.25.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.3.tgz",
-			"integrity": "sha512-QsYW7UeAaXvLPX9tdVliMJE7MD7M6MLYVTovRTIwhoYQVFHR1rM4wO8wqAezYi3/BpSD+NzVCZ69R6smWiIi8g==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.4.tgz",
+			"integrity": "sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.25.2",
+				"@babel/compat-data": "^7.25.4",
 				"@babel/helper-compilation-targets": "^7.25.2",
 				"@babel/helper-plugin-utils": "^7.24.8",
 				"@babel/helper-validator-option": "^7.24.8",
@@ -2532,13 +2532,13 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.24.7",
-				"@babel/plugin-transform-async-generator-functions": "^7.25.0",
+				"@babel/plugin-transform-async-generator-functions": "^7.25.4",
 				"@babel/plugin-transform-async-to-generator": "^7.24.7",
 				"@babel/plugin-transform-block-scoped-functions": "^7.24.7",
 				"@babel/plugin-transform-block-scoping": "^7.25.0",
-				"@babel/plugin-transform-class-properties": "^7.24.7",
+				"@babel/plugin-transform-class-properties": "^7.25.4",
 				"@babel/plugin-transform-class-static-block": "^7.24.7",
-				"@babel/plugin-transform-classes": "^7.25.0",
+				"@babel/plugin-transform-classes": "^7.25.4",
 				"@babel/plugin-transform-computed-properties": "^7.24.7",
 				"@babel/plugin-transform-destructuring": "^7.24.8",
 				"@babel/plugin-transform-dotall-regex": "^7.24.7",
@@ -2566,7 +2566,7 @@
 				"@babel/plugin-transform-optional-catch-binding": "^7.24.7",
 				"@babel/plugin-transform-optional-chaining": "^7.24.8",
 				"@babel/plugin-transform-parameters": "^7.24.7",
-				"@babel/plugin-transform-private-methods": "^7.24.7",
+				"@babel/plugin-transform-private-methods": "^7.25.4",
 				"@babel/plugin-transform-private-property-in-object": "^7.24.7",
 				"@babel/plugin-transform-property-literals": "^7.24.7",
 				"@babel/plugin-transform-regenerator": "^7.24.7",
@@ -2579,10 +2579,10 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.24.7",
 				"@babel/plugin-transform-unicode-property-regex": "^7.24.7",
 				"@babel/plugin-transform-unicode-regex": "^7.24.7",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.24.7",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.25.4",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.4",
+				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"core-js-compat": "^3.37.1",
 				"semver": "^6.3.1"
@@ -2633,9 +2633,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-			"integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.4.tgz",
+			"integrity": "sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -2669,15 +2669,15 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.25.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
-			"integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
+			"integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
 			"dependencies": {
 				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.25.0",
-				"@babel/parser": "^7.25.3",
+				"@babel/generator": "^7.25.4",
+				"@babel/parser": "^7.25.4",
 				"@babel/template": "^7.25.0",
-				"@babel/types": "^7.25.2",
+				"@babel/types": "^7.25.4",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2686,9 +2686,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-			"integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+			"integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.24.8",
 				"@babel/helper-validator-identifier": "^7.24.7",
@@ -3058,18 +3058,18 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.16",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.16.tgz",
-			"integrity": "sha512-mxJEzDORt+Wx39jEh/0Hql3HDvYL5+URDB98XEmvTE6Wl79ZwScdEz10RMz+5FiMdpWl6RwyO3Zn/jGuwmxl9Q==",
+			"version": "13.0.17",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.17.tgz",
+			"integrity": "sha512-Jh2MfrSK/gEmnHkE8e96XvNHCGM1wEFKIKrfkhKNEqlWhTQssvsjLRkq9XABStebf99Jannji82dFXML4+BecA==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^9.0.1",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.12",
+				"@natlibfi/sru-client": "^6.0.14",
 				"debug": "^4.3.6",
 				"deep-eql": "^5.0.2",
 				"http-status": "^1.7.4",
 				"moment": "^2.30.1",
-				"nock": "^13.5.4"
+				"nock": "^13.5.5"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3088,9 +3088,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.9.tgz",
-			"integrity": "sha512-58yusIdTZrSLa9tM6Bsa1f9FrwkVJFlpLLWAxOdRlLfnpm+BBmam0dQYfDggypWHy+on+lFYALqcdTue73FJcQ==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.10.tgz",
+			"integrity": "sha512-kxeRIXFKipEsCm3K65bsy4Nd02BBwtlTKH9aqsJKZWbJjPzeUA+dq8kG9U2mzGq0taJjNFjA4b4z0Ynk6Ddrrg==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^9.0.1",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
@@ -7525,9 +7525,9 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -7646,9 +7646,9 @@
 			}
 		},
 		"node_modules/nock": {
-			"version": "13.5.4",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-			"integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+			"version": "13.5.5",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.5.tgz",
+			"integrity": "sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==",
 			"dependencies": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "MIT",
-	"version": "3.3.10",
+	"version": "3.3.11-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -34,7 +34,7 @@
 		"@natlibfi/marc-record-serializers": "^10.1.2",
 		"@natlibfi/melinda-backend-commons": "^2.3.1",
 		"@natlibfi/melinda-commons": "^13.0.16",
-		"@natlibfi/melinda-rest-api-commons": "^4.1.9",
+		"@natlibfi/melinda-rest-api-commons": "^4.1.10",
 		"@natlibfi/passport-melinda-aleph": "^2.0.4",
 		"@natlibfi/sru-client": "^6.0.14",
 		"body-parser": "^1.20.2",


### PR DESCRIPTION
* Bump the development-dependencies group with 2 updates (#292)

Bumps the development-dependencies group with 2 updates: [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-runtime) and [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env).


* Bump the production-dependencies group with 2 updates (#291)

Bumps the production-dependencies group with 2 updates: [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime) and [@natlibfi/melinda-commons](https://github.com/natlibfi/melinda-commons-js).

* Update deps

* 3.3.11-alpha.1