### PR TITLE
Dependency update (#300)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.3.11",
+	"version": "3.3.12-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.3.11",
+			"version": "3.3.12-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.25.0",
@@ -940,9 +940,9 @@
 			"optional": true
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.24.8.tgz",
-			"integrity": "sha512-isdp+G6DpRyKc+3Gqxy2rjzgF7Zj9K0mzLNnxz+E/fgeag8qT3vVulX4gY9dGO1q0y+0lUv6V3a+uhUzMzrwXg==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.25.6.tgz",
+			"integrity": "sha512-Z+Doemr4VtvSD2SNHTrkiFZ1LX+JI6tyRXAAOb4N9khIuPyoEPmTPJarPm8ljJV1D6bnMQjyHMWTT9NeKbQuXA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
@@ -962,7 +962,7 @@
 			},
 			"optionalDependencies": {
 				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
-				"chokidar": "^3.4.0"
+				"chokidar": "^3.6.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -2633,9 +2633,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.25.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.4.tgz",
-			"integrity": "sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+			"integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "MIT",
-	"version": "3.3.11",
+	"version": "3.3.12-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
* Bump @babel/cli in the development-dependencies group (#299)

Bumps the development-dependencies group with 1 update: [@babel/cli](https://github.com/babel/babel/tree/HEAD/packages/babel-cli).

* Bump @babel/runtime in the production-dependencies group (#298)

Bumps the production-dependencies group with 1 update: [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime).

* 3.3.12-alpha.1