### PR TITLE
Feature match failures as new

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.4.1",
+	"version": "3.5.0-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.4.1",
+			"version": "3.5.0-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.26.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"mongo-sanitize": "^1.1.0",
 				"nodemon": "^3.1.9",
 				"passport": "^0.7.0",
-				"uuid": "^11.0.5"
+				"uuid": "^11.1.0"
 			},
 			"devDependencies": {
 				"@babel/cli": "^7.26.4",
@@ -2844,9 +2844,9 @@
 			}
 		},
 		"node_modules/bson": {
-			"version": "6.10.2",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.2.tgz",
-			"integrity": "sha512-5afhLTjqDSA3akH56E+/2J6kTDuSIlBxyXPdQslj9hcIgOUE378xdOfZvC/9q3LifJNI6KR/juZ+d0NRNYBwXg==",
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+			"integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.20.1"
@@ -2933,9 +2933,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001700",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
-			"integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
+			"version": "1.0.30001701",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
+			"integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3518,9 +3518,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.102",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
-			"integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
+			"version": "1.5.105",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.105.tgz",
+			"integrity": "sha512-ccp7LocdXx3yBhwiG0qTQ7XFrK48Ua2pxIxBdJO8cbddp/MvbBtPFzvnTchtyHQTsgqqczO8cdmAIbpMa0u2+g==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -4415,9 +4415,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fastq": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-			"integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -4670,17 +4670,17 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-			"integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
+				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
+				"es-object-atoms": "^1.1.1",
 				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.0",
+				"get-proto": "^1.0.1",
 				"gopd": "^1.2.0",
 				"has-symbols": "^1.1.0",
 				"hasown": "^2.0.2",
@@ -6137,20 +6137,20 @@
 			"license": "MIT"
 		},
 		"node_modules/mongodb": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.0.tgz",
-			"integrity": "sha512-KeESYR5TEaFxOuwRqkOm3XOsMqCSkdeDMjaW5u2nuKfX7rqaofp7JQGoi7sVqQcNJTKuveNbzZtWMstb8ABP6Q==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.1.tgz",
+			"integrity": "sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.1.9",
-				"bson": "^6.10.1",
+				"bson": "^6.10.3",
 				"mongodb-connection-string-url": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=16.20.1"
 			},
 			"peerDependencies": {
-				"@aws-sdk/credential-providers": "^3.188.0",
+				"@aws-sdk/credential-providers": "^3.632.0",
 				"@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
 				"gcp-metadata": "^5.2.0",
 				"kerberos": "^2.0.1",
@@ -7174,9 +7174,9 @@
 			}
 		},
 		"node_modules/reusify": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8214,9 +8214,9 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "11.0.5",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-			"integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -8467,12 +8467,12 @@
 			}
 		},
 		"node_modules/xregexp": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.1.tgz",
-			"integrity": "sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.2.tgz",
+			"integrity": "sha512-6hGgEMCGhqCTFEJbqmWrNIPqfpdirdGWkqshu7fFZddmTSfgv5Sn9D2SaKloR79s5VUiUlpwzg3CM3G6D3VIlw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime-corejs3": "^7.16.5"
+				"@babel/runtime-corejs3": "^7.26.9"
 			}
 		},
 		"node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"mongo-sanitize": "^1.1.0",
 		"nodemon": "^3.1.9",
 		"passport": "^0.7.0",
-		"uuid": "^11.0.5"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.26.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "MIT",
-	"version": "3.4.1",
+	"version": "3.5.0-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/src/api.json
+++ b/src/api.json
@@ -71,6 +71,14 @@
             }
           },
           {
+            "name": "matchFailuresAsNew",
+            "description": "Handle merge jobs where are all matches fail matchValidation as new.",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "cataloger",
             "description": "Cataloger name to use while operating on a record. Note: requires admin rights to use",
             "in": "query",
@@ -307,6 +315,14 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "matchFailuresAsNew",
+            "description": "Handle merge jobs where are all matches fail matchValidation as new.",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
             }
           },
           {

--- a/src/api.yaml
+++ b/src/api.yaml
@@ -231,6 +231,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: matchFailuresAsNew
+          description: >-
+            Handle merge jobs where are all matches fail matchValidation as new
+          in: query
+          schema:
+            type: boolean
         - name: cataloger
           description: >-
             Cataloger name to use while operating on a record. Note: requires admin rights to use
@@ -404,6 +410,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: matchFailuresAsNew
+          description: >-
+            Handle merge jobs where are all matches fail matchValidation as new
+          in: query
+          schema:
+            type: boolean
         - name: pRejectFile
           description: Error log file location
           in: query

--- a/src/interfaces/bulk.js
+++ b/src/interfaces/bulk.js
@@ -328,7 +328,7 @@ export default async function ({mongoUri, amqpUrl, allowedLibs}) {
     const paramUnique = queryParams.unique ? parseBoolean(queryParams.unique) : undefined;
     const paramMerge = queryParams.merge ? parseBoolean(queryParams.merge) : undefined;
     const paramSkipLowValidation = queryParams.skipLowValidation ? parseBoolean(queryParams.skipLowValidateLow) : undefined;
-
+    const paramMatchFailuresAsNew = queryParams.matchFailuresAsNew ? parseBoolean(queryParams.matchFailuresAsNew) : undefined;
 
     if (paramValidate === false && (paramUnique || paramMerge)) {
       logger.debug(`Query parameter validate=0 is not valid with query parameters unique=1 and/or merge=1`);
@@ -354,6 +354,7 @@ export default async function ({mongoUri, amqpUrl, allowedLibs}) {
       failOnError: queryParams.failOnError === undefined ? false : parseBoolean(queryParams.failOnError),
       // bulk skips changes that won't change the database record as default
       skipNoChangeUpdates: queryParams.skipNoChangeUpdates === undefined ? true : parseBoolean(queryParams.skipNoChangeUpdates),
+      matchFailuresAsNew: paramMatchFailuresAsNew,
       prio: false
     };
 

--- a/src/routes/prio.js
+++ b/src/routes/prio.js
@@ -116,6 +116,7 @@ export default async ({sruUrl, amqpUrl, mongoUri, pollWaitTime, recordType, requ
         failOnError: null,
         // Prio forces updates as default, even if the update would not make changes to the database record
         skipNoChangeUpdates: req.query.skipNoChangeUpdates === undefined ? false : parseBoolean(req.query.skipNoChangeUpdates),
+        matchFailuresAsNew: req.query.matchFailuresAsNew === undefined ? undefined : parseBoolean(req.query.matchFailuresAsNew),
         prio: true
       };
 

--- a/src/routes/queryUtils.js
+++ b/src/routes/queryUtils.js
@@ -24,6 +24,7 @@ export function checkQueryParams(req, res, next) {
     {name: 'skipLowValidation', value: queryParams.skipLowValidation ? (/^(?:1|0|true|false)$/ui).test(queryParams.skipLowValidation) : true},
     {name: 'failOnError', value: queryParams.failOnError ? (/^(?:1|0|true|false)$/ui).test(queryParams.failOnError) : true},
     {name: 'skipNoChangeUpdates', value: queryParams.skipNoChangeUpdates ? (/^(?:1|0|true|false)$/ui).test(queryParams.skipNoChangeUpdates) : true},
+    {name: 'maatchFailuresAsNew', value: queryParams.matchFailuresAsNew ? (/^(?:1|0|true|false)$/ui).test(queryParams.matchFailuresAsNew) : true},
     {name: 'pRejectFile', value: queryParams.pRejectFile ? (/^[a-z|A-Z|0-9|/|.|_|-]{0,100}$/u).test(queryParams.pRejectFile) : true},
     {name: 'pLogFile', value: queryParams.pLogFile ? (/^[a-z|A-Z|0-9|/|.|_|-]{0,100}$/u).test(queryParams.pLogFile) : true},
     {name: 'pCatalogerIn', value: queryParams.pCatalogerIn ? (/^(?:0|false|undefined|[A-Z|0-9|_|-]{0,10}$)/u).test(queryParams.pCatalogerIn) : true},


### PR DESCRIPTION
Add query parameter matchFailuresAsNew to handle CREATE-merge jobs where there are matches found, but all of them are failed in matchValidation as CREATEs instead of erroring them.