### PR TITLE
Feature add records (#375)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.5.0",
+	"version": "3.6.0-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.5.0",
+			"version": "3.6.0-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.26.9",
@@ -69,9 +69,9 @@
 			}
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.26.4",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.26.4.tgz",
-			"integrity": "sha512-+mORf3ezU3p3qr+82WvJSnQNE1GAYeoCfEv4fik6B5/2cvKZ75AX8oawWQdXtM9MmndooQj15Jr9kelRFWsuRw==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.0.tgz",
+			"integrity": "sha512-bZfxn8DRxwiVzDO5CEeV+7IqXeCkzI4yYnrQbpwjT76CUyossQc6RYE7n+xfm0/2k40lPaCpW0FhxYs7EBAetw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -124,22 +124,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-			"integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+			"integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.9",
+				"@babel/generator": "^7.26.10",
 				"@babel/helper-compilation-targets": "^7.26.5",
 				"@babel/helper-module-transforms": "^7.26.0",
-				"@babel/helpers": "^7.26.9",
-				"@babel/parser": "^7.26.9",
+				"@babel/helpers": "^7.26.10",
+				"@babel/parser": "^7.26.10",
 				"@babel/template": "^7.26.9",
-				"@babel/traverse": "^7.26.9",
-				"@babel/types": "^7.26.9",
+				"@babel/traverse": "^7.26.10",
+				"@babel/types": "^7.26.10",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -174,14 +174,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-			"integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+			"integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.26.9",
-				"@babel/types": "^7.26.9",
+				"@babel/parser": "^7.27.0",
+				"@babel/types": "^7.27.0",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -442,14 +442,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-			"integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+			"integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.26.9",
-				"@babel/types": "^7.26.9"
+				"@babel/template": "^7.27.0",
+				"@babel/types": "^7.27.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -480,13 +480,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-			"integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+			"integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.26.9"
+				"@babel/types": "^7.27.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1331,16 +1331,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.26.9.tgz",
-			"integrity": "sha512-Jf+8y9wXQbbxvVYTM8gO5oEF2POdNji0NMltEkG7FtmzD9PVz7/lxpqSdTvwsjTMU5HIHuDVNf2SOxLkWi+wPQ==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.26.10.tgz",
+			"integrity": "sha512-NWaL2qG6HRpONTnj4JvDU6th4jYeZOJgu3QhmFTCihib0ermtOJqktA5BduGm3suhhVe9EMP9c9+mfJ/I9slqw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.25.9",
 				"@babel/helper-plugin-utils": "^7.26.5",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.6",
+				"babel-plugin-polyfill-corejs3": "^0.11.0",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"semver": "^6.3.1"
 			},
@@ -1583,20 +1583,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-			"integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.3",
-				"core-js-compat": "^3.40.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-			}
-		},
 		"node_modules/@babel/preset-modules": {
 			"version": "0.1.6-no-external-plugins",
 			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -1633,9 +1619,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-			"integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+			"integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
 			"license": "MIT",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -1658,32 +1644,32 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-			"integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+			"integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
-				"@babel/parser": "^7.26.9",
-				"@babel/types": "^7.26.9"
+				"@babel/parser": "^7.27.0",
+				"@babel/types": "^7.27.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
-			"integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+			"integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.9",
-				"@babel/parser": "^7.26.9",
-				"@babel/template": "^7.26.9",
-				"@babel/types": "^7.26.9",
+				"@babel/generator": "^7.27.0",
+				"@babel/parser": "^7.27.0",
+				"@babel/template": "^7.27.0",
+				"@babel/types": "^7.27.0",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -1692,9 +1678,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-			"integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+			"integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2129,13 +2115,13 @@
 			}
 		},
 		"node_modules/@natlibfi/passport-melinda-aleph": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@natlibfi/passport-melinda-aleph/-/passport-melinda-aleph-3.0.7.tgz",
-			"integrity": "sha512-UczAWSd4Q627h5HPpr0HOk30KYLEbYn1pcvnbksrUgwGnH0jt9irPP3Gy57NuW+t7QYVWoeEYNRwS2ytPIEA6A==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@natlibfi/passport-melinda-aleph/-/passport-melinda-aleph-3.0.8.tgz",
+			"integrity": "sha512-BQ+BwI3ePhsv4NgR9Y+zaSrnLphq6HHTRk7fu+9dUOZNOd6COe+To32nFyNIvHXWeBRPJ9DbQRRHBkK7UaJFUg==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/melinda-commons": "^13.0.19",
-				"@xmldom/xmldom": "^0.9.7",
+				"@xmldom/xmldom": "^0.9.8",
 				"debug": "^4.4.0",
 				"http-status": "^2.1.0",
 				"passport": "^0.7.0",
@@ -2154,9 +2140,9 @@
 			}
 		},
 		"node_modules/@natlibfi/sru-client": {
-			"version": "6.0.17",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.17.tgz",
-			"integrity": "sha512-R4eLs0P1/DJ4Q5AtVtFkvzallY/fTDsUXxt+sfD/xquaxwM6T0igz9jEInaYjL03jTaZ+AfmGBdu0HdW4w33UQ==",
+			"version": "6.0.18",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.18.tgz",
+			"integrity": "sha512-ilTCts8AziSnBu99176lPwZtGuCYeHr+bJvBg/64RXcL7wpAXqb7j2x9RPDKRAuNWaLOR97TX6kYHYMgCUh7rQ==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.0",
@@ -2452,9 +2438,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.9.7",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.7.tgz",
-			"integrity": "sha512-syvR8iIJjpTZ/stv7l89UAViwGFh6lbheeOaqSxkYx9YNmIVvPTRH+CT/fpykFtUx5N+8eSMDRvggF9J8GEPzQ==",
+			"version": "0.9.8",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+			"integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.6"
@@ -2696,14 +2682,14 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.10.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
-			"integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+			"integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.2",
-				"core-js-compat": "^3.38.0"
+				"@babel/helper-define-polyfill-provider": "^0.6.3",
+				"core-js-compat": "^3.40.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "MIT",
-	"version": "3.5.0",
+	"version": "3.6.0-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/src/api.json
+++ b/src/api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Melinda REST API for ILS integration ",
-    "version": "2.3"
+    "version": "2.4"
   },
   "tags": [
     {
@@ -853,6 +853,49 @@
               },
               "example": {
                 "$ref": "#/components/examples/ISO2709"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/bulk/records/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "description": "Queue item identifier (correlationId)",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/correlationId"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Add a records (max 100) to a bulk job",
+        "tags": [
+          "/bulk/"
+        ],
+        "security": [
+          {
+            "httpBasic": []
+          }
+        ],
+        "requestBody": {
+          "description": "Array that contains several records",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/marcRecord"
+                }
               }
             }
           }

--- a/src/api.yaml
+++ b/src/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: 'Melinda REST API for ILS integration '
-  version: '2.3'
+  version: '2.4'
 tags:
   - name: /
     description: Operate on single bibliographic records
@@ -611,6 +611,32 @@ paths:
               format: binary
             example:
               $ref: '#/components/examples/ISO2709'
+      responses:
+        '200':
+          description: OK
+  /bulk/records/{id}:
+    parameters:
+      - name: id
+        description: Queue item identifier (correlationId)
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/correlationId'
+    post:
+      summary: Add records (max 100) to a bulk job
+      tags:
+        - /bulk/
+      security:
+        - httpBasic: []
+      requestBody:
+        description: Contains an array of records
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/marcRecord'
       responses:
         '200':
           description: OK

--- a/src/config.js
+++ b/src/config.js
@@ -27,11 +27,12 @@ export const recordType = readEnvironmentVariable('RECORD_TYPE', {defaultValue: 
 export const requireAuthForRead = readEnvironmentVariable('REQUIRE_AUTH_FOR_READ', {defaultValue: false, format: v => parseBoolean(v)});
 export const requireKVPForWrite = readEnvironmentVariable('REQUIRE_KVP_FOR_WRITE', {defaultValue: false, format: v => parseBoolean(v)});
 
+// NOTE: currently only application/json is allowed for adding records by chunk
 export const CONTENT_TYPES = [
-  {contentType: 'application/json', conversionFormat: CONVERSION_FORMATS.JSON, allowPrio: true, allowBulk: true},
-  {contentType: 'application/marc', conversionFormat: CONVERSION_FORMATS.ISO2709, allowPrio: true, allowBulk: true},
-  {contentType: 'application/xml', conversionFormat: CONVERSION_FORMATS.MARCXML, allowPrio: true, allowBulk: true},
-  {contentType: 'application/alephseq', conversionFormat: CONVERSION_FORMATS.ALEPHSEQ, allowPrio: false, allowBulk: true}
+  {contentType: 'application/json', conversionFormat: CONVERSION_FORMATS.JSON, allowPrio: true, allowBulk: true, allowAddRecords: true},
+  {contentType: 'application/marc', conversionFormat: CONVERSION_FORMATS.ISO2709, allowPrio: true, allowBulk: true, allowAddRecords: false},
+  {contentType: 'application/xml', conversionFormat: CONVERSION_FORMATS.MARCXML, allowPrio: true, allowBulk: true, allowAddRecords: false},
+  {contentType: 'application/alephseq', conversionFormat: CONVERSION_FORMATS.ALEPHSEQ, allowPrio: false, allowBulk: true, allowAddRecords: false}
 ];
 
 export const DEFAULT_ACCEPT = readEnvironmentVariable('DEFAULT_ACCEPT', {defaultValue: 'application/json'});

--- a/src/routes/routeUtils.js
+++ b/src/routes/routeUtils.js
@@ -71,6 +71,14 @@ export function checkContentType(req, res, next) {
   const result = req.headers['content-type'] === undefined ? undefined : CONTENT_TYPES.find(({contentType}) => contentType === req.headers['content-type']);
   logger.debug(`routesUtils:checkContentType: Found defined contentType: ${JSON.stringify(result)}`);
 
+  if ((/^\/records[/?]/u).test(req.originalUrl)) {
+    logger.debug(`Checking contentType for addRecords (path: ${req.originalUrl})`);
+    if (!result || result.allowAddRecords === false) {
+      return res.status(httpStatus.UNSUPPORTED_MEDIA_TYPE).send('Invalid content-type');
+    }
+    return next();
+  }
+
   if ((/^\/bulk[/?]/u).test(req.originalUrl)) {
     logger.debug(`Checking contentType for bulk (path: ${req.originalUrl})`);
     if (!result || result.allowBulk === false) {


### PR DESCRIPTION
* Add endpoint /bulk/records for adding a chunk of maximum of 100 records to bulk -- record input only as an application/json array of marc-record-js records
* API version 2.4

* Bump the development-dependencies group across 1 directory with 3 updates (#373)

Bumps the development-dependencies group with 3 updates in the / directory: [@babel/cli](https://github.com/babel/babel/tree/HEAD/packages/babel-cli), [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) and [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-runtime).


* Bump the production-dependencies group across 1 directory with 3 updates (#372)

Bumps the production-dependencies group with 3 updates in the / directory: [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime), [@natlibfi/passport-melinda-aleph](https://github.com/natlibfi/passport-melinda-aleph-js) and [@natlibfi/sru-client](https://github.com/natlibfi/sru-client-js).

* Update deps

* 3.6.0-alpha.1