### PR TITLE
Dependency update (#393)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.6.1",
+	"version": "3.6.2-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.6.1",
+			"version": "3.6.2-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.27.3",
@@ -110,9 +110,9 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.3.tgz",
-			"integrity": "sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==",
+			"version": "7.27.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
+			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -121,10 +121,10 @@
 				"@babel/generator": "^7.27.3",
 				"@babel/helper-compilation-targets": "^7.27.2",
 				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.3",
-				"@babel/parser": "^7.27.3",
+				"@babel/helpers": "^7.27.4",
+				"@babel/parser": "^7.27.4",
 				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.27.3",
+				"@babel/traverse": "^7.27.4",
 				"@babel/types": "^7.27.3",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -428,14 +428,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.3.tgz",
-			"integrity": "sha512-h/eKy9agOya1IGuLaZ9tEUgz+uIRXcbtOhRtUyyMf8JFmn1iT13vnl/IGVWSkdOCG/pC57U4S1jnAabAavTMwg==",
+			"version": "7.27.6",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+			"integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.3"
+				"@babel/types": "^7.27.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -466,9 +466,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
-			"integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
+			"version": "7.27.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+			"integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1317,9 +1317,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.3.tgz",
-			"integrity": "sha512-bA9ZL5PW90YwNgGfjg6U+7Qh/k3zCEQJ06BFgAGRp/yMjw9hP9UGbGPtx3KSOkHGljEPCCxaE+PH4fUR2h1sDw==",
+			"version": "7.27.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.4.tgz",
+			"integrity": "sha512-D68nR5zxU64EUzV8i7T3R5XP0Xhrou/amNnddsRQssx6GrTLdZl1rLxyjtVZBd+v/NVX4AbTPOB5aU8thAZV1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1605,9 +1605,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.3.tgz",
-			"integrity": "sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==",
+			"version": "7.27.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -1641,15 +1641,15 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
-			"integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
+			"version": "7.27.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
+			"integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.27.3",
-				"@babel/parser": "^7.27.3",
+				"@babel/parser": "^7.27.4",
 				"@babel/template": "^7.27.2",
 				"@babel/types": "^7.27.3",
 				"debug": "^4.3.1",
@@ -1660,9 +1660,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-			"integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+			"version": "7.27.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+			"integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1760,9 +1760,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1826,9 +1826,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2797,9 +2797,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3998,9 +3998,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4791,9 +4791,9 @@
 			}
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6359,9 +6359,9 @@
 			}
 		},
 		"node_modules/nodemon/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "MIT",
-	"version": "3.6.1",
+	"version": "3.6.2-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
* Bump brace-expansion from 1.1.11 to 1.1.12 (#392)


* Bump @babel/runtime in the production-dependencies group (#394)

* Bump the development-dependencies group with 2 updates (#395)

Bumps the development-dependencies group with 2 updates: [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) and [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-runtime).

* 3.6.2-alpha.1