### PR TITLE
IpWhiteList (#407)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: mikaelvesavuori/license-compliance-action@main
         with:
           exclude_pattern: /^@natlibfi/
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: nodejsscan scan
       id: njsscan
       uses: ajinabraham/njsscan-action@master
@@ -59,7 +59,7 @@ jobs:
     if: github.actor!= 'dependabot[bot]'   # ignore the pull request which comes from user dependabot, because it does not access to secrets
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,25 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "3.6.2",
+	"version": "3.7.0-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "3.6.2",
+			"version": "3.7.0-alpha.1",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.27.3",
+				"@babel/runtime": "^7.28.3",
 				"@natlibfi/marc-record-serializers": "^10.1.6",
-				"@natlibfi/melinda-backend-commons": "^2.3.8",
-				"@natlibfi/melinda-commons": "^13.0.20",
+				"@natlibfi/melinda-backend-commons": "^2.3.9",
+				"@natlibfi/melinda-commons": "^13.0.21",
 				"@natlibfi/melinda-rest-api-commons": "^4.2.5",
-				"@natlibfi/passport-melinda-aleph": "^3.0.8",
+				"@natlibfi/passport-melinda-aleph": "^3.0.10",
 				"@natlibfi/sru-client": "^6.0.18",
 				"body-parser": "^2.2.0",
 				"express": "^4.21.2",
 				"http-status": "^2.1.0",
+				"ip-range-check": "^0.2.0",
 				"moment": "^2.30.1",
 				"mongo-sanitize": "^1.1.0",
 				"nodemon": "^3.1.10",
@@ -26,13 +27,13 @@
 				"uuid": "^11.1.0"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.27.2",
-				"@babel/core": "^7.27.3",
-				"@babel/node": "^7.27.1",
-				"@babel/plugin-transform-runtime": "^7.27.3",
-				"@babel/preset-env": "^7.27.2",
-				"@babel/register": "^7.27.1",
-				"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
+				"@babel/cli": "^7.28.3",
+				"@babel/core": "^7.28.3",
+				"@babel/node": "^7.28.0",
+				"@babel/plugin-transform-runtime": "^7.28.3",
+				"@babel/preset-env": "^7.28.3",
+				"@babel/register": "^7.28.3",
+				"@natlibfi/eslint-config-melinda-backend": "^3.0.6",
 				"cross-env": "^7.0.3",
 				"eslint": "^8.57.1"
 			},
@@ -55,13 +56,13 @@
 			}
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.2.tgz",
-			"integrity": "sha512-cfd7DnGlhH6OIyuPSSj3vcfIdnbXukhAyKY8NaZrFadC7pXyL9mOL5WgjcptiEJLi5k3j8aYvLIVCzezrWTaiA==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.28.3.tgz",
+			"integrity": "sha512-n1RU5vuCX0CsaqaXm9I0KUCNKNQMy5epmzl/xdSSm70bSqhg9GWhgeosypyQLc0bK24+Xpk1WGzZlI9pJtkZdg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@jridgewell/trace-mapping": "^0.3.28",
 				"commander": "^6.2.0",
 				"convert-source-map": "^2.0.0",
 				"fs-readdir-recursive": "^1.1.0",
@@ -100,9 +101,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.3.tgz",
-			"integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+			"integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -110,22 +111,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
+			"integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
+				"@babel/generator": "^7.28.3",
 				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.4",
-				"@babel/parser": "^7.27.4",
+				"@babel/helper-module-transforms": "^7.28.3",
+				"@babel/helpers": "^7.28.3",
+				"@babel/parser": "^7.28.3",
 				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.27.4",
-				"@babel/types": "^7.27.3",
+				"@babel/traverse": "^7.28.3",
+				"@babel/types": "^7.28.2",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -141,9 +142,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.27.1.tgz",
-			"integrity": "sha512-q8rjOuadH0V6Zo4XLMkJ3RMQ9MSBqwaDByyYB0izsYdaIWGNLmEblbCOf1vyFHICcg16CD7Fsi51vcQnYxmt6Q==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.0.tgz",
+			"integrity": "sha512-N4ntErOlKvcbTt01rr5wj3y55xnIdx1ymrfIr8C2WnM1Y9glFgWaGDEULJIazOX3XM9NRzhfJ6zZnQ1sBNWU+w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -160,16 +161,16 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
-			"integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+			"integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.27.3",
-				"@babel/types": "^7.27.3",
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@babel/parser": "^7.28.3",
+				"@babel/types": "^7.28.2",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
 			},
 			"engines": {
@@ -207,18 +208,18 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-			"integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+			"integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-annotate-as-pure": "^7.27.3",
 				"@babel/helper-member-expression-to-functions": "^7.27.1",
 				"@babel/helper-optimise-call-expression": "^7.27.1",
 				"@babel/helper-replace-supers": "^7.27.1",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-				"@babel/traverse": "^7.27.1",
+				"@babel/traverse": "^7.28.3",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -247,20 +248,30 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
-			"integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+			"integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.22.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"debug": "^4.1.1",
+				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"debug": "^4.4.1",
 				"lodash.debounce": "^4.0.8",
-				"resolve": "^1.14.2"
+				"resolve": "^1.22.10"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+			}
+		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
@@ -292,15 +303,15 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-			"integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.27.1",
 				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.27.3"
+				"@babel/traverse": "^7.28.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -413,38 +424,38 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
-			"integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
+			"integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.27.1",
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/template": "^7.27.2",
+				"@babel/traverse": "^7.28.3",
+				"@babel/types": "^7.28.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-			"integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
+			"integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.6"
+				"@babel/types": "^7.28.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/node": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.27.1.tgz",
-			"integrity": "sha512-ef8ZrhxIku9LrphvyNywpiMf1UJsYQll7S4eKa228ivswPcwmObp98o5h5wL2n9FrSAuo1dsMwJ8cS1LEcBSog==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.28.0.tgz",
+			"integrity": "sha512-6u1Mmn3SIMUH8uwTq543L062X3JDgms9HPf06o/pIGdDjeD/zNQ+dfZPQD27sCyvtP0ZOlJtwnl2RIdPe9bHeQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -466,13 +477,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-			"integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+			"integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.27.3"
+				"@babel/types": "^7.28.2"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -549,14 +560,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
-			"integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
+			"integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/traverse": "^7.27.1"
+				"@babel/traverse": "^7.28.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -644,15 +655,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
-			"integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
+			"integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.27.1",
 				"@babel/helper-remap-async-to-generator": "^7.27.1",
-				"@babel/traverse": "^7.27.1"
+				"@babel/traverse": "^7.28.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -696,9 +707,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.3.tgz",
-			"integrity": "sha512-+F8CnfhuLhwUACIJMLWnjz6zvzYM2r0yeIHKlbgfw7ml8rOMJsXNXV/hyRcb3nb493gRs4WvYpQAndWj/qQmkQ==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
+			"integrity": "sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -729,13 +740,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
-			"integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
+			"integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
+				"@babel/helper-create-class-features-plugin": "^7.28.3",
 				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
@@ -746,18 +757,18 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
-			"integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.3.tgz",
+			"integrity": "sha512-DoEWC5SuxuARF2KdKmGUq3ghfPMO6ZzR12Dnp5gubwbeWJo4dbNWXJPVlwvh4Zlq6Z7YVvL8VFxeSOJgjsx4Sg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.1",
-				"@babel/helper-compilation-targets": "^7.27.1",
+				"@babel/helper-annotate-as-pure": "^7.27.3",
+				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-globals": "^7.28.0",
 				"@babel/helper-plugin-utils": "^7.27.1",
 				"@babel/helper-replace-supers": "^7.27.1",
-				"@babel/traverse": "^7.27.1",
-				"globals": "^11.1.0"
+				"@babel/traverse": "^7.28.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -784,13 +795,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
-			"integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
+			"integrity": "sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/traverse": "^7.28.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -857,6 +869,23 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
+			"integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/plugin-transform-destructuring": "^7.28.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1132,16 +1161,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
-			"integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
+			"integrity": "sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.27.2",
 				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/plugin-transform-destructuring": "^7.27.3",
-				"@babel/plugin-transform-parameters": "^7.27.1"
+				"@babel/plugin-transform-destructuring": "^7.28.0",
+				"@babel/plugin-transform-parameters": "^7.27.7",
+				"@babel/traverse": "^7.28.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1201,9 +1231,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
-			"integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+			"version": "7.27.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+			"integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1268,9 +1298,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.1.tgz",
-			"integrity": "sha512-B19lbbL7PMrKr52BNPjCqg1IyNUIjTcxKj8uX9zHO+PmWN93s19NDr/f69mIkEp2x9nmDJ08a7lgHaTTzvW7mw==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.3.tgz",
+			"integrity": "sha512-K3/M/a4+ESb5LEldjQb+XSrpY0nF+ZBFlTCbSnKaYAMfD8v33O6PMs4uYnOk19HlcsI8WMu3McdFPTiQHF/1/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1317,17 +1347,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.4.tgz",
-			"integrity": "sha512-D68nR5zxU64EUzV8i7T3R5XP0Xhrou/amNnddsRQssx6GrTLdZl1rLxyjtVZBd+v/NVX4AbTPOB5aU8thAZV1A==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
+			"integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.27.1",
 				"@babel/helper-plugin-utils": "^7.27.1",
-				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.11.0",
-				"babel-plugin-polyfill-regenerator": "^0.6.1",
+				"babel-plugin-polyfill-corejs2": "^0.4.14",
+				"babel-plugin-polyfill-corejs3": "^0.13.0",
+				"babel-plugin-polyfill-regenerator": "^0.6.5",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1486,13 +1516,13 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
-			"integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz",
+			"integrity": "sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
+				"@babel/compat-data": "^7.28.0",
 				"@babel/helper-compilation-targets": "^7.27.2",
 				"@babel/helper-plugin-utils": "^7.27.1",
 				"@babel/helper-validator-option": "^7.27.1",
@@ -1500,25 +1530,26 @@
 				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-import-assertions": "^7.27.1",
 				"@babel/plugin-syntax-import-attributes": "^7.27.1",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.27.1",
-				"@babel/plugin-transform-async-generator-functions": "^7.27.1",
+				"@babel/plugin-transform-async-generator-functions": "^7.28.0",
 				"@babel/plugin-transform-async-to-generator": "^7.27.1",
 				"@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-				"@babel/plugin-transform-block-scoping": "^7.27.1",
+				"@babel/plugin-transform-block-scoping": "^7.28.0",
 				"@babel/plugin-transform-class-properties": "^7.27.1",
-				"@babel/plugin-transform-class-static-block": "^7.27.1",
-				"@babel/plugin-transform-classes": "^7.27.1",
+				"@babel/plugin-transform-class-static-block": "^7.28.3",
+				"@babel/plugin-transform-classes": "^7.28.3",
 				"@babel/plugin-transform-computed-properties": "^7.27.1",
-				"@babel/plugin-transform-destructuring": "^7.27.1",
+				"@babel/plugin-transform-destructuring": "^7.28.0",
 				"@babel/plugin-transform-dotall-regex": "^7.27.1",
 				"@babel/plugin-transform-duplicate-keys": "^7.27.1",
 				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
 				"@babel/plugin-transform-dynamic-import": "^7.27.1",
+				"@babel/plugin-transform-explicit-resource-management": "^7.28.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.27.1",
 				"@babel/plugin-transform-export-namespace-from": "^7.27.1",
 				"@babel/plugin-transform-for-of": "^7.27.1",
@@ -1535,15 +1566,15 @@
 				"@babel/plugin-transform-new-target": "^7.27.1",
 				"@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
 				"@babel/plugin-transform-numeric-separator": "^7.27.1",
-				"@babel/plugin-transform-object-rest-spread": "^7.27.2",
+				"@babel/plugin-transform-object-rest-spread": "^7.28.0",
 				"@babel/plugin-transform-object-super": "^7.27.1",
 				"@babel/plugin-transform-optional-catch-binding": "^7.27.1",
 				"@babel/plugin-transform-optional-chaining": "^7.27.1",
-				"@babel/plugin-transform-parameters": "^7.27.1",
+				"@babel/plugin-transform-parameters": "^7.27.7",
 				"@babel/plugin-transform-private-methods": "^7.27.1",
 				"@babel/plugin-transform-private-property-in-object": "^7.27.1",
 				"@babel/plugin-transform-property-literals": "^7.27.1",
-				"@babel/plugin-transform-regenerator": "^7.27.1",
+				"@babel/plugin-transform-regenerator": "^7.28.3",
 				"@babel/plugin-transform-regexp-modifiers": "^7.27.1",
 				"@babel/plugin-transform-reserved-words": "^7.27.1",
 				"@babel/plugin-transform-shorthand-properties": "^7.27.1",
@@ -1556,10 +1587,10 @@
 				"@babel/plugin-transform-unicode-regex": "^7.27.1",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.11.0",
-				"babel-plugin-polyfill-regenerator": "^0.6.1",
-				"core-js-compat": "^3.40.0",
+				"babel-plugin-polyfill-corejs2": "^0.4.14",
+				"babel-plugin-polyfill-corejs3": "^0.13.0",
+				"babel-plugin-polyfill-regenerator": "^0.6.5",
+				"core-js-compat": "^3.43.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1585,9 +1616,9 @@
 			}
 		},
 		"node_modules/@babel/register": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.27.1.tgz",
-			"integrity": "sha512-K13lQpoV54LATKkzBpBAEu1GGSIRzxR9f4IN4V8DCDgiUMo2UDGagEZr3lPeVNJPLkWUi5JE4hCHKneVTwQlYQ==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.28.3.tgz",
+			"integrity": "sha512-CieDOtd8u208eI49bYl4z1J22ySFw87IGwE+IswFEExH7e3rLgKb0WNQeumnacQ1+VoDJLYI5QFA3AJZuyZQfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1605,21 +1636,21 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+			"integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.3.tgz",
-			"integrity": "sha512-ZYcgrwb+dkWNcDlsTe4fH1CMdqMDSJ5lWFd1by8Si2pI54XcQjte/+ViIPqAk7EAWisaUxvQ89grv+bNX2x8zg==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.3.tgz",
+			"integrity": "sha512-LKYxD2CIfocUFNREQ1yk+dW+8OH8CRqmgatBZYXb+XhuObO8wsDpEoCNri5bKld9cnj8xukqZjxSX8p1YiRF8Q==",
 			"license": "MIT",
 			"dependencies": {
-				"core-js-pure": "^3.30.2"
+				"core-js-pure": "^3.43.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1641,28 +1672,28 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-			"integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+			"integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
-				"@babel/parser": "^7.27.4",
+				"@babel/generator": "^7.28.3",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.28.3",
 				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.3",
-				"debug": "^4.3.1",
-				"globals": "^11.1.0"
+				"@babel/types": "^7.28.2",
+				"debug": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
-			"integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
+			"version": "7.28.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+			"integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1770,22 +1801,6 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1872,18 +1887,14 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -1896,27 +1907,17 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.30",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+			"integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1925,23 +1926,23 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
-			"integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
+			"integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
 			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
 		"node_modules/@natlibfi/eslint-config-melinda-backend": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.5.tgz",
-			"integrity": "sha512-7UE/las5+S4XiQkFO1Z0qHqKJaPUgLqvCGEgKy0aY3A0CoyZAaEi/3K0UUYgw9C7MAxySbGKSVr1ESv3Ub3vUg==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.6.tgz",
+			"integrity": "sha512-vzb2LAckioNO2Ge+E4NMSqXa4F7t+K9LMNZaIhx73KTrk7Xez+t0MqwdvmCf30RkHiupcEmmlRmO45u7l8sQPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/eslint-parser": "^7.22.15",
-				"@typescript-eslint/type-utils": "^6.7.2",
+				"@babel/eslint-parser": "^7.27.5",
+				"@typescript-eslint/type-utils": "^6.21.0",
 				"@typescript-eslint/utils": "^6.4.1",
 				"eslint-plugin-functional": "^5.0.8"
 			},
@@ -1959,12 +1960,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "9.1.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-9.1.5.tgz",
-			"integrity": "sha512-7daEZgo9CgwQooS5MPG/CdTD4zTXGGHfArOB7GU0j0vcCI72Y8MuQKf0hBMslaCUHxREN/Vz2ZXFWUwn7IAYQA==",
+			"version": "9.1.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-9.1.6.tgz",
+			"integrity": "sha512-ceYJMRK3BHx3FpaRo7x8kMcC3iEj7CVgn8YFvqDyJJ7RdvKlSnfi8D15wrOjZPJxhi+R1UAmBXMWZzAMnWnORw==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.4.0",
+				"debug": "^4.4.1",
 				"jsonschema": "^1.5.0"
 			},
 			"engines": {
@@ -2004,22 +2005,22 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "11.6.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.6.6.tgz",
-			"integrity": "sha512-4W55+W/HEDDMU4R1AFHx5kyjJJ6Ld1bxFKafER7T54UdM1x316i2i//LWejhlzncY07gv4tEmPLBi4NUX4/KoQ==",
+			"version": "11.6.7",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-11.6.7.tgz",
+			"integrity": "sha512-zobGy0Y3tCWm+FoO+QF9S4bJuhhUX7RPdjTNXysQDOjEvCq5lC0gvlxGbYlx0cdFq7wtAmQADE6t9yQdf+2qoA==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/issn-verify": "^1.0.6",
-				"@natlibfi/marc-record": "^9.1.5",
+				"@natlibfi/marc-record": "^9.1.6",
 				"@natlibfi/marc-record-serializers": "^10.1.6",
 				"@natlibfi/marc-record-validate": "^8.0.14",
-				"@natlibfi/melinda-commons": "^13.0.20",
+				"@natlibfi/melinda-commons": "^13.0.21",
 				"@natlibfi/sfs-4900": "github:NatLibFi/sfs-4900",
 				"@natlibfi/sru-client": "^6.0.18",
 				"cld3-asm": "^4.0.0",
 				"clone": "^2.1.2",
 				"debug": "^4.4.0",
-				"isbn3": "^1.2.10",
+				"isbn3": "^1.2.13",
 				"iso9_1995": "^0.0.2",
 				"langs": "^2.0.0",
 				"node-fetch": "^2.7.0",
@@ -2034,17 +2035,17 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.3.8.tgz",
-			"integrity": "sha512-YvTfZDLXhFkMfyyHHpvQP+dW7gCZdm7PqQa7sW+HvN5TQcKgPYv3wfVfyn4iM0NTf1CGgg0S4uRPwCVC2p6vqA==",
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.3.9.tgz",
+			"integrity": "sha512-rX9kR+UtVIM70XbwBkZJKnAbuJOUsNh3e4veFpwT80SROQIBdrI6DiO3NIOXOGbaYuN51bQLGI7YXNxAZmEYeg==",
 			"license": "MIT",
 			"dependencies": {
 				"base64-url": "^2.3.3",
-				"debug": "^4.4.0",
+				"debug": "^4.4.1",
 				"express-winston": "^4.2.0",
 				"html-to-text": "^9.0.5",
 				"moment": "^2.30.1",
-				"nodemailer": "^7.0.2",
+				"nodemailer": "^7.0.3",
 				"pretty-print-ms": "^1.0.5",
 				"winston": "^3.17.0",
 				"yargs": "^17.7.2"
@@ -2059,15 +2060,15 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.20",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.20.tgz",
-			"integrity": "sha512-CdFy6WHfJckDsGYzvK6KVovZrgANjbGMcJGNZCdEZFauozq+1l433/XK4Rjati5VQwlePNB/j8n5vnFgtYSooA==",
+			"version": "13.0.21",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.21.tgz",
+			"integrity": "sha512-RlAbp52n8jr5ytMmwM+G2Qg+955xcsHzNGWuOVmQ+3ov0ZUm0KIUXghQr8qbHFsBTeq983hJueJ0L99i7WobtA==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^9.1.4",
+				"@natlibfi/marc-record": "^9.1.5",
 				"@natlibfi/marc-record-serializers": "^10.1.6",
 				"@natlibfi/sru-client": "^6.0.18",
-				"debug": "^4.4.0"
+				"debug": "^4.4.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2097,14 +2098,15 @@
 			}
 		},
 		"node_modules/@natlibfi/passport-melinda-aleph": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@natlibfi/passport-melinda-aleph/-/passport-melinda-aleph-3.0.8.tgz",
-			"integrity": "sha512-BQ+BwI3ePhsv4NgR9Y+zaSrnLphq6HHTRk7fu+9dUOZNOd6COe+To32nFyNIvHXWeBRPJ9DbQRRHBkK7UaJFUg==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@natlibfi/passport-melinda-aleph/-/passport-melinda-aleph-3.0.10.tgz",
+			"integrity": "sha512-oNp5TmXtzHrNQ7+YLdK75I/Crl+qbT3raMxrhKYdrPcGw0zZKBF7LyJJ4ibStmXsAVUs2ajMQQiReAuDadkODw==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/melinda-commons": "^13.0.19",
+				"@babel/runtime": "^7.27.6",
+				"@natlibfi/melinda-commons": "^13.0.21",
 				"@xmldom/xmldom": "^0.9.8",
-				"debug": "^4.4.0",
+				"debug": "^4.4.1",
 				"http-status": "^2.1.0",
 				"passport": "^0.7.0",
 				"passport-http": "^0.3.0"
@@ -2442,9 +2444,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.14.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -2649,14 +2651,14 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
-			"integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+			"integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.6.4",
+				"@babel/compat-data": "^7.27.7",
+				"@babel/helper-define-polyfill-provider": "^0.6.5",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -2664,27 +2666,27 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-			"integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+			"integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.3",
-				"core-js-compat": "^3.40.0"
+				"@babel/helper-define-polyfill-provider": "^0.6.5",
+				"core-js-compat": "^3.43.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
-			"integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+			"integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.4"
+				"@babel/helper-define-polyfill-provider": "^0.6.5"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2737,65 +2739,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/body-parser/node_modules/media-typer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/body-parser/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/body-parser/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/body-parser/node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/body-parser/node_modules/type-is": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^1.0.5",
-				"media-typer": "^1.1.0",
-				"mime-types": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2819,9 +2762,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.5",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-			"integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+			"version": "4.25.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
+			"integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2839,8 +2782,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001716",
-				"electron-to-chromium": "^1.5.149",
+				"caniuse-lite": "^1.0.30001733",
+				"electron-to-chromium": "^1.5.199",
 				"node-releases": "^2.0.19",
 				"update-browserslist-db": "^1.1.3"
 			},
@@ -2852,9 +2795,9 @@
 			}
 		},
 		"node_modules/bson": {
-			"version": "6.10.3",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-			"integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
+			"version": "6.10.4",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+			"integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.20.1"
@@ -2941,9 +2884,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001718",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-			"integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+			"version": "1.0.30001735",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
+			"integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
 			"dev": true,
 			"funding": [
 				{
@@ -3182,9 +3125,9 @@
 			"license": "MIT"
 		},
 		"node_modules/core-js": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
-			"integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
+			"version": "3.45.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.0.tgz",
+			"integrity": "sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -3194,13 +3137,13 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
-			"integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
+			"version": "3.45.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz",
+			"integrity": "sha512-gRoVMBawZg0OnxaVv3zpqLLxaHmsubEGyTnqdpI/CEBvX4JadI1dMSHxagThprYRtSVbuQxvi6iUatdPxohHpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.24.4"
+				"browserslist": "^4.25.1"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3208,9 +3151,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.42.0.tgz",
-			"integrity": "sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==",
+			"version": "3.45.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.0.tgz",
+			"integrity": "sha512-OtwjqcDpY2X/eIIg1ol/n0y/X8A9foliaNt1dSK0gV3J2/zw+89FcNG3mPK+N8YWts4ZFUPxnrAzsxs/lf8yDA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -3506,9 +3449,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.159",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.159.tgz",
-			"integrity": "sha512-CEvHptWAMV5p6GJ0Lq8aheyvVbfzVrv5mmidu1D3pidoVNkB3tTBsTMVtPJ+rzRK5oV229mCLz9Zj/hNvU8GBA==",
+			"version": "1.5.203",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.203.tgz",
+			"integrity": "sha512-uz4i0vLhfm6dLZWbz/iH88KNDV+ivj5+2SA+utpgjKaj9Q0iDLuwk6Idhe9BTxciHudyx6IvTvijhkPvFGUQ0g==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3560,9 +3503,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.23.10",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.10.tgz",
-			"integrity": "sha512-MtUbM072wlJNyeYAe0mhzrD+M6DIJa96CZAOBBrhDbgKnB4MApIKefcyAB1eOdYn8cUNZgvwBvEzdoAYsxgEIw==",
+			"version": "1.24.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+			"integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3593,7 +3536,9 @@
 				"is-array-buffer": "^3.0.5",
 				"is-callable": "^1.2.7",
 				"is-data-view": "^1.0.2",
+				"is-negative-zero": "^2.0.3",
 				"is-regex": "^1.2.1",
+				"is-set": "^2.0.3",
 				"is-shared-array-buffer": "^1.0.4",
 				"is-string": "^1.1.1",
 				"is-typed-array": "^1.1.15",
@@ -3608,6 +3553,7 @@
 				"safe-push-apply": "^1.0.0",
 				"safe-regex-test": "^1.1.0",
 				"set-proto": "^1.0.0",
+				"stop-iteration-iterator": "^1.1.0",
 				"string.prototype.trim": "^1.2.10",
 				"string.prototype.trimend": "^1.0.9",
 				"string.prototype.trimstart": "^1.0.8",
@@ -4061,22 +4007,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/eslint/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/eslint/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4374,11 +4304,35 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/express/node_modules/media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/express/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
+		},
+		"node_modules/express/node_modules/qs": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.0.6"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/express/node_modules/raw-body": {
 			"version": "2.5.2",
@@ -4393,6 +4347,19 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/express/node_modules/type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"license": "MIT",
+			"dependencies": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -4815,13 +4782,19 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/globalthis": {
@@ -5142,6 +5115,15 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ip-range-check": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ip-range-check/-/ip-range-check-0.2.0.tgz",
+			"integrity": "sha512-oaM3l/3gHbLlt/tCWLvt0mj1qUaI+STuRFnUvARGCujK9vvU61+2JsDpmkMzR4VsJhuFXWWgeKKVnwwoFfzCqw==",
+			"license": "MIT",
+			"dependencies": {
+				"ipaddr.js": "^1.0.1"
 			}
 		},
 		"node_modules/ipaddr.js": {
@@ -5557,6 +5539,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-negative-zero": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5771,9 +5766,9 @@
 			"license": "MIT"
 		},
 		"node_modules/isbn3": {
-			"version": "1.2.10",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.2.10.tgz",
-			"integrity": "sha512-JWzRvXxK9fIXgoLAAedKMXNF8mlbwNiGENyhbZR5ECdsq3tKl8ifdtLQ5R8WQzynFESTdnfbSHfrxr9cbjbgQA==",
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.2.13.tgz",
+			"integrity": "sha512-03qteThCLmn1DHBRl8EaXEZlY0NR6C4QpVBxZWz7OYR3ygFViSGu8kA8k2zCetEBe5zHmnOJnsuDINf1dFvw1Q==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",
@@ -6035,12 +6030,12 @@
 			}
 		},
 		"node_modules/media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
 			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/memory-pager": {
@@ -6156,13 +6151,13 @@
 			"license": "MIT"
 		},
 		"node_modules/mongodb": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
-			"integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
+			"integrity": "sha512-fO5ttN9VC8P0F5fqtQmclAkgXZxbIkYRTUi1j8JO6IYwvamkhtYDilJr35jOPELR49zqCJgXZWwCtW7B+TM8vQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.1.9",
-				"bson": "^6.10.3",
+				"bson": "^6.10.4",
 				"mongodb-connection-string-url": "^3.0.0"
 			},
 			"engines": {
@@ -6322,9 +6317,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nodemailer": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
-			"integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+			"integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
@@ -6918,12 +6913,12 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.0.6"
+				"side-channel": "^1.1.0"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -7670,6 +7665,20 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/stop-iteration-iterator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+			"integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"internal-slot": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/stream-chain": {
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
@@ -7944,13 +7953,35 @@
 			}
 		},
 		"node_modules/type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
 			"license": "MIT",
 			"dependencies": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
+				"content-type": "^1.0.5",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/type-is/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/type-is/node_modules/mime-types": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
@@ -8035,9 +8066,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "MIT",
-	"version": "3.6.2",
+	"version": "3.7.0-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -30,16 +30,17 @@
 		"prod": "NODE_ENV=production npm run build && npm run start"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.27.3",
+		"@babel/runtime": "^7.28.3",
 		"@natlibfi/marc-record-serializers": "^10.1.6",
-		"@natlibfi/melinda-backend-commons": "^2.3.8",
-		"@natlibfi/melinda-commons": "^13.0.20",
+		"@natlibfi/melinda-backend-commons": "^2.3.9",
+		"@natlibfi/melinda-commons": "^13.0.21",
 		"@natlibfi/melinda-rest-api-commons": "^4.2.5",
-		"@natlibfi/passport-melinda-aleph": "^3.0.8",
+		"@natlibfi/passport-melinda-aleph": "^3.0.10",
 		"@natlibfi/sru-client": "^6.0.18",
 		"body-parser": "^2.2.0",
 		"express": "^4.21.2",
 		"http-status": "^2.1.0",
+		"ip-range-check": "^0.2.0",
 		"moment": "^2.30.1",
 		"mongo-sanitize": "^1.1.0",
 		"nodemon": "^3.1.10",
@@ -47,13 +48,13 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.27.2",
-		"@babel/core": "^7.27.3",
-		"@babel/node": "^7.27.1",
-		"@babel/plugin-transform-runtime": "^7.27.3",
-		"@babel/preset-env": "^7.27.2",
-		"@babel/register": "^7.27.1",
-		"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
+		"@babel/cli": "^7.28.3",
+		"@babel/core": "^7.28.3",
+		"@babel/node": "^7.28.0",
+		"@babel/plugin-transform-runtime": "^7.28.3",
+		"@babel/preset-env": "^7.28.3",
+		"@babel/register": "^7.28.3",
+		"@natlibfi/eslint-config-melinda-backend": "^3.0.6",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.57.1"
 	},

--- a/src/config.js
+++ b/src/config.js
@@ -41,3 +41,5 @@ export const fixTypes = readEnvironmentVariable('FIX_TYPES', {defaultValue: ['DE
 
 // We default allowedLibs to empty array for backwards compatibility, as it is anyways checked in aleph-record-load-api
 export const allowedLibs = readEnvironmentVariable('ALLOWED_LIBS', {defaultValue: []});
+
+export const ipWhiteList = readEnvironmentVariable('IP_WHITELIST', {defaultValue: [], format: v => JSON.parse(v)});


### PR DESCRIPTION
* Add IpWhiteList feature

* Bump the development-dependencies group across 1 directory with 7 updates (#406)

| Package | From | To |
| --- | --- | --- |
| [@babel/cli](https://github.com/babel/babel/tree/HEAD/packages/babel-cli) | `7.27.2` | `7.28.3` |
| [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) | `7.27.4` | `7.28.3` | 
| [@babel/node](https://github.com/babel/babel/tree/HEAD/packages/babel-node) | `7.27.1` | `7.28.0` |
| [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-runtime) | `7.27.4` | `7.28.3` |
| [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env) | `7.27.2` | `7.28.3` |
| [@babel/register](https://github.com/babel/babel/tree/HEAD/packages/babel-register) | `7.27.1` | `7.28.3` |
| [@natlibfi/eslint-config-melinda-backend](https://github.com/natlibfi/eslint-config-melinda-backend) | `3.0.5` | `3.0.6` |


* Bump the production-dependencies group across 1 directory with 4 updates (#404)

Bumps the production-dependencies group with 4 updates in the / directory: [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime), [@natlibfi/melinda-backend-commons](https://github.com/natlibfi/melinda-backend-commons-js), [@natlibfi/melinda-commons](https://github.com/natlibfi/melinda-commons-js) and [@natlibfi/passport-melinda-aleph](https://github.com/natlibfi/passport-melinda-aleph-js).

* Bump actions/checkout from 4 to 5 (#405)

Bumps [actions/checkout](https://github.com/actions/checkout) from 4 to 5.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v4...v5)


* 3.7.0-alpha.1