### PR TITLE
Dependency update (#443)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "4.0.0",
+	"version": "4.0.1-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "4.0.0",
+			"version": "4.0.1-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record-serializers": "^11.0.1",
-				"@natlibfi/melinda-backend-commons": "^3.0.2",
+				"@natlibfi/melinda-backend-commons": "^3.0.4",
 				"@natlibfi/melinda-commons": "^14.0.2",
-				"@natlibfi/melinda-rest-api-commons": "^5.0.4",
+				"@natlibfi/melinda-rest-api-commons": "^5.0.6",
 				"@natlibfi/passport-melinda-aleph": "^4.0.0",
 				"@natlibfi/sru-client": "^7.0.1",
 				"body-parser": "^2.2.2",
-				"esbuild": "^0.27.2",
+				"esbuild": "^0.27.4",
 				"express": "^4.22.1",
 				"http-status": "^2.1.0",
 				"ip-range-check": "^0.2.0",
@@ -27,19 +27,19 @@
 			},
 			"devDependencies": {
 				"cross-env": "^10.1.0",
-				"eslint": "^9.39.2"
+				"eslint": "^9.39.4"
 			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
-			"integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+			"integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
 			"license": "MIT",
 			"dependencies": {
-				"core-js-pure": "^3.43.0"
+				"core-js-pure": "^3.48.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -73,9 +73,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-			"integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+			"integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
 			"cpu": [
 				"ppc64"
 			],
@@ -89,9 +89,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-			"integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+			"integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
 			"cpu": [
 				"arm"
 			],
@@ -105,9 +105,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-			"integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+			"integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
 			"cpu": [
 				"arm64"
 			],
@@ -121,9 +121,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-			"integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+			"integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
 			"cpu": [
 				"x64"
 			],
@@ -137,9 +137,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-			"integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+			"integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -153,9 +153,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-			"integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+			"integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
 			"cpu": [
 				"x64"
 			],
@@ -169,9 +169,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-			"integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
 			"cpu": [
 				"arm64"
 			],
@@ -185,9 +185,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-			"integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+			"integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
 			"cpu": [
 				"x64"
 			],
@@ -201,9 +201,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-			"integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+			"integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
 			"cpu": [
 				"arm"
 			],
@@ -217,9 +217,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-			"integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+			"integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
 			"cpu": [
 				"arm64"
 			],
@@ -233,9 +233,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-			"integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+			"integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
 			"cpu": [
 				"ia32"
 			],
@@ -249,9 +249,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-			"integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+			"integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
 			"cpu": [
 				"loong64"
 			],
@@ -265,9 +265,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-			"integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+			"integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -281,9 +281,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-			"integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+			"integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -297,9 +297,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-			"integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+			"integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -313,9 +313,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-			"integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+			"integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
 			"cpu": [
 				"s390x"
 			],
@@ -329,9 +329,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-			"integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+			"integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
 			"cpu": [
 				"x64"
 			],
@@ -345,9 +345,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-			"integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -361,9 +361,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-			"integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
 			"cpu": [
 				"x64"
 			],
@@ -377,9 +377,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-			"integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
 			"cpu": [
 				"arm64"
 			],
@@ -393,9 +393,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-			"integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
 			"cpu": [
 				"x64"
 			],
@@ -409,9 +409,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-			"integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+			"integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
 			"cpu": [
 				"arm64"
 			],
@@ -425,9 +425,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-			"integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+			"integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
 			"cpu": [
 				"x64"
 			],
@@ -441,9 +441,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-			"integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+			"integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
 			"cpu": [
 				"arm64"
 			],
@@ -457,9 +457,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-			"integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+			"integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
 			"cpu": [
 				"ia32"
 			],
@@ -473,9 +473,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-			"integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+			"integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
 			"cpu": [
 				"x64"
 			],
@@ -531,15 +531,15 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.2"
+				"minimatch": "^3.1.5"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -572,20 +572,20 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"debug": "^4.3.2",
 				"espree": "^10.0.1",
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.1",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.5",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
@@ -596,9 +596,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-			"integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -685,18 +685,18 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.4.tgz",
-			"integrity": "sha512-p7X/ytJDIdwUfFL/CLOhKgdfJe1Fa8uw9seJYvdOmnP9JBWGWHW69HkOixXS6Wy9yvGf1MbhcS6lVmrhy4jm2g==",
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
+			"integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
 			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
 		"node_modules/@natlibfi/iso9-1995": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/iso9-1995/-/iso9-1995-1.1.0.tgz",
-			"integrity": "sha512-pDQKeV9ZWJj0i1u0x60VG2mGvmFtUrbTnA9vhyfMHr7FVakCDkI9fzr3u7db4I4pP9hJlH8+zHmjAxgAz3Ppig==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/iso9-1995/-/iso9-1995-1.1.1.tgz",
+			"integrity": "sha512-OmK3ph9s55nISjhkWK0Jk63geZUjxbKULwmFtiBdTpY2mAAVxckXhG442DJYwlj93IFdzbHxpknwrZVIc0bhIg==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.3"
@@ -706,9 +706,9 @@
 			}
 		},
 		"node_modules/@natlibfi/issn-verify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/issn-verify/-/issn-verify-2.0.1.tgz",
-			"integrity": "sha512-suFZLEGq0sg/cbMQ7i5D0W3zUHAv+uQCFT8b3Ik9ddMUe/cBu8a6oBa5gjaNUJGrTeozh5Y4x1h8j2kiU+RDsQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/issn-verify/-/issn-verify-2.0.2.tgz",
+			"integrity": "sha512-2/HfVM6FdhE3MbsH1M+X3PQ24emnAjf5U4xQexMmZfdPNwOCLxTI2KZBRiJmzWllPXSTcPy/b2mrNtBZBU+YIw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22"
@@ -759,25 +759,23 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "12.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.4.tgz",
-			"integrity": "sha512-PmssCOXhtnm3B21wIEBNmS8NJ9LPW6bVwQK0g7Sz4DVbTrdkFWYcSucvlYLcLvZGiKhqsbqFr3zjmjAnBPh+Aw==",
+			"version": "12.0.11",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.11.tgz",
+			"integrity": "sha512-DrdlWIFVWJL4vVv4wgLs/Vx5Uvhpmpdh2wylqeOg/L8fAg0sOIPN05QChOXNyvb5PuGTJxV+ZxiF6Bw6VCJMMw==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/iso9-1995": "^1.0.0",
-				"@natlibfi/issn-verify": "^2.0.0",
+				"@natlibfi/iso9-1995": "^1.1.1",
+				"@natlibfi/issn-verify": "^2.0.2",
 				"@natlibfi/marc-record": "^10.0.1",
 				"@natlibfi/marc-record-serializers": "^11.0.1",
 				"@natlibfi/marc-record-validate": "^9.0.0",
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/sfs-4900": "^2.0.0",
 				"@natlibfi/sru-client": "^7.0.1",
-				"cld3-asm": "^4.0.0",
 				"clone": "^2.1.2",
 				"debug": "^4.4.3",
-				"isbn3": "^2.0.2",
-				"langs": "^2.0.0",
-				"undici": "^7.18.0",
+				"franc": "^6.2.0",
+				"isbn3": "^2.0.6",
 				"xml2js": "^0.6.2",
 				"xregexp": "^5.1.2"
 			},
@@ -789,9 +787,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.2.tgz",
-			"integrity": "sha512-PGHNBa4y7sRaSxxlNHSwDaRO9BbrZ2sCYGenUJOLmxH0AieFaFukligQB5SNua/W5r5608dfY8025p40urlgAw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.4.tgz",
+			"integrity": "sha512-w3BrCaevmU5xA4iiG06nvW/TU8rzpf/b90eyyS4ukwozXArTEpVaIRj/cLKMfKnX/f0vaFjAydoqk+I6K6aZ2g==",
 			"license": "MIT",
 			"dependencies": {
 				"base64-url": "^2.3.3",
@@ -799,7 +797,7 @@
 				"express-winston": "^4.2.0",
 				"html-to-text": "^9.0.5",
 				"moment": "^2.30.1",
-				"nodemailer": "^7.0.12",
+				"nodemailer": "^7.0.13",
 				"winston": "^3.19.0",
 				"yargs": "^18.0.0"
 			},
@@ -828,16 +826,16 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-5.0.4.tgz",
-			"integrity": "sha512-d1cfSHlL6JytQJM3UNOFfQNuCTt4QEp9H3M1Ox5YUl8nMN+51T7Ugw8lBOfTCHu+umkDVyOW89aW3HBXhZx7hQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-5.0.6.tgz",
+			"integrity": "sha512-9zDZxIrmKIYXXmPGha2cGQ7h1gh6YDi5YGglG02McdsdZL2/LKi7OekS5b0WHDzRZcPo0M0gy67kWoyV6ZJYIA==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.1",
 				"@natlibfi/marc-record-serializers": "^11.0.1",
 				"@natlibfi/marc-record-validate": "^9.0.0",
-				"@natlibfi/marc-record-validators-melinda": "^12.0.4",
-				"@natlibfi/melinda-backend-commons": "^3.0.2",
+				"@natlibfi/marc-record-validators-melinda": "^12.0.10",
+				"@natlibfi/melinda-backend-commons": "^3.0.4",
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"amqplib": "^0.10.9",
 				"debug": "^4.4.3",
@@ -975,9 +973,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -998,9 +996,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1205,18 +1203,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/cld3-asm": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cld3-asm/-/cld3-asm-4.0.0.tgz",
-			"integrity": "sha512-eQq2detA7A54X9NSeunvHf4KcWlZKE/i98+V6NjWNDqF28GGk8Qk9XWApSywBjEcmPKR48zkabFWBoa1ExM/AQ==",
-			"license": "MIT",
-			"dependencies": {
-				"emscripten-wasm-loader": "^3.0.3"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/cliui": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -1238,6 +1224,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8"
+			}
+		},
+		"node_modules/collapse-white-space": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+			"integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/color": {
@@ -1359,9 +1355,9 @@
 			"license": "MIT"
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.47.0.tgz",
-			"integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+			"integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -1535,20 +1531,6 @@
 			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
 			"license": "MIT"
 		},
-		"node_modules/emscripten-wasm-loader": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/emscripten-wasm-loader/-/emscripten-wasm-loader-3.0.3.tgz",
-			"integrity": "sha512-fyq2maBt5LOou27LEBlL5H6G04BxgSamXkvmMsAuIT6rd8ioH4BxNQhuyl6jVPeODh6U8Wk1BoFZxzHpg3o8wA==",
-			"license": "MIT",
-			"dependencies": {
-				"getroot": "^1.0.0",
-				"nanoid": "^2.0.3",
-				"unixify": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/enabled": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
@@ -1607,9 +1589,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-			"integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+			"integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -1619,32 +1601,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.2",
-				"@esbuild/android-arm": "0.27.2",
-				"@esbuild/android-arm64": "0.27.2",
-				"@esbuild/android-x64": "0.27.2",
-				"@esbuild/darwin-arm64": "0.27.2",
-				"@esbuild/darwin-x64": "0.27.2",
-				"@esbuild/freebsd-arm64": "0.27.2",
-				"@esbuild/freebsd-x64": "0.27.2",
-				"@esbuild/linux-arm": "0.27.2",
-				"@esbuild/linux-arm64": "0.27.2",
-				"@esbuild/linux-ia32": "0.27.2",
-				"@esbuild/linux-loong64": "0.27.2",
-				"@esbuild/linux-mips64el": "0.27.2",
-				"@esbuild/linux-ppc64": "0.27.2",
-				"@esbuild/linux-riscv64": "0.27.2",
-				"@esbuild/linux-s390x": "0.27.2",
-				"@esbuild/linux-x64": "0.27.2",
-				"@esbuild/netbsd-arm64": "0.27.2",
-				"@esbuild/netbsd-x64": "0.27.2",
-				"@esbuild/openbsd-arm64": "0.27.2",
-				"@esbuild/openbsd-x64": "0.27.2",
-				"@esbuild/openharmony-arm64": "0.27.2",
-				"@esbuild/sunos-x64": "0.27.2",
-				"@esbuild/win32-arm64": "0.27.2",
-				"@esbuild/win32-ia32": "0.27.2",
-				"@esbuild/win32-x64": "0.27.2"
+				"@esbuild/aix-ppc64": "0.27.4",
+				"@esbuild/android-arm": "0.27.4",
+				"@esbuild/android-arm64": "0.27.4",
+				"@esbuild/android-x64": "0.27.4",
+				"@esbuild/darwin-arm64": "0.27.4",
+				"@esbuild/darwin-x64": "0.27.4",
+				"@esbuild/freebsd-arm64": "0.27.4",
+				"@esbuild/freebsd-x64": "0.27.4",
+				"@esbuild/linux-arm": "0.27.4",
+				"@esbuild/linux-arm64": "0.27.4",
+				"@esbuild/linux-ia32": "0.27.4",
+				"@esbuild/linux-loong64": "0.27.4",
+				"@esbuild/linux-mips64el": "0.27.4",
+				"@esbuild/linux-ppc64": "0.27.4",
+				"@esbuild/linux-riscv64": "0.27.4",
+				"@esbuild/linux-s390x": "0.27.4",
+				"@esbuild/linux-x64": "0.27.4",
+				"@esbuild/netbsd-arm64": "0.27.4",
+				"@esbuild/netbsd-x64": "0.27.4",
+				"@esbuild/openbsd-arm64": "0.27.4",
+				"@esbuild/openbsd-x64": "0.27.4",
+				"@esbuild/openharmony-arm64": "0.27.4",
+				"@esbuild/sunos-x64": "0.27.4",
+				"@esbuild/win32-arm64": "0.27.4",
+				"@esbuild/win32-ia32": "0.27.4",
+				"@esbuild/win32-x64": "0.27.4"
 			}
 		},
 		"node_modules/escalade": {
@@ -1676,25 +1658,25 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.1",
+				"@eslint/config-array": "^0.21.2",
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.39.2",
+				"@eslint/eslintrc": "^3.3.5",
+				"@eslint/js": "9.39.4",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
@@ -1713,7 +1695,7 @@
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -2031,6 +2013,21 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
 		},
+		"node_modules/express/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/express/node_modules/raw-body": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
@@ -2164,9 +2161,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -2183,6 +2180,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/franc": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/franc/-/franc-6.2.0.tgz",
+			"integrity": "sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==",
+			"license": "MIT",
+			"dependencies": {
+				"trigram-utils": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/fresh": {
@@ -2213,9 +2223,9 @@
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-			"integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -2259,19 +2269,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/getroot": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/getroot/-/getroot-1.0.0.tgz",
-			"integrity": "sha512-W9Q31kOv921dQuZBeAbK4R/dAPbC0WkhZD3alLcdVwjSkEtS1aX8twrzG3I5yo0sQ88M/d4JOqVbRiCuI/XPNA==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^1.7.1"
-			},
-			"engines": {
-				"node": ">=4.2.4",
-				"npm": ">=3.0.0"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -2523,9 +2520,9 @@
 			}
 		},
 		"node_modules/isbn3": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.3.tgz",
-			"integrity": "sha512-HDDcGtTyvZK5TBV6PYntlSH3SFEgC0idO1HJT69xNCx/ZmW5oxwHvHtY+Cd1e++18sPcS/Fs4q1EfXeFM/EmLg==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.6.tgz",
+			"integrity": "sha512-RrJy7jsXki4+QK/D2/ZH2lKi3oOr+xcgIMf2VXrDZ3DduE4awmu2XJ0Z/zu5j0L6XIGWbJUhe0UYD2BlRgwLrA==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",
@@ -2602,12 +2599,6 @@
 			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
 			"license": "MIT"
 		},
-		"node_modules/langs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/langs/-/langs-2.0.0.tgz",
-			"integrity": "sha512-v4pxOBEQVN1WBTfB1crhTtxzNLZU9HPWgadlwzWKISJtt6Ku/CnpBrwVy+jFv8StjxsPfwPFzO0CMwdZLJ0/BA==",
-			"license": "MIT"
-		},
 		"node_modules/leac": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
@@ -2648,9 +2639,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
@@ -2753,9 +2744,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2842,22 +2833,14 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
-		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
+		"node_modules/n-gram": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+			"integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
 			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/natural-compare": {
@@ -2877,24 +2860,12 @@
 			}
 		},
 		"node_modules/nodemailer": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.12.tgz",
-			"integrity": "sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==",
+			"version": "7.0.13",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+			"integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-			"license": "MIT",
-			"dependencies": {
-				"remove-trailing-separator": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-inspect": {
@@ -3125,9 +3096,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -3183,12 +3154,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
-			"license": "ISC"
-		},
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -3241,9 +3206,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sax": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -3485,12 +3450,12 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -3552,6 +3517,20 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/trigram-utils": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
+			"integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"collapse-white-space": "^2.0.0",
+				"n-gram": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/triple-beam": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -3560,12 +3539,6 @@
 			"engines": {
 				"node": ">= 14.0.0"
 			}
-		},
-		"node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"license": "0BSD"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -3617,27 +3590,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/undici": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-			"integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.18.1"
-			}
-		},
-		"node_modules/unixify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
-			"integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
-			"license": "MIT",
-			"dependencies": {
-				"normalize-path": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "MIT",
-	"version": "4.0.0",
+	"version": "4.0.1-alpha.1",
 	"main": "dist/index.js",
 	"type": "module",
 	"engines": {
@@ -35,13 +35,13 @@
 	},
 	"dependencies": {
 		"@natlibfi/marc-record-serializers": "^11.0.1",
-		"@natlibfi/melinda-backend-commons": "^3.0.2",
+		"@natlibfi/melinda-backend-commons": "^3.0.4",
 		"@natlibfi/melinda-commons": "^14.0.2",
-		"@natlibfi/melinda-rest-api-commons": "^5.0.4",
+		"@natlibfi/melinda-rest-api-commons": "^5.0.6",
 		"@natlibfi/passport-melinda-aleph": "^4.0.0",
 		"@natlibfi/sru-client": "^7.0.1",
 		"body-parser": "^2.2.2",
-		"esbuild": "^0.27.2",
+		"esbuild": "^0.27.4",
 		"express": "^4.22.1",
 		"http-status": "^2.1.0",
 		"ip-range-check": "^0.2.0",
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"cross-env": "^10.1.0",
-		"eslint": "^9.39.2"
+		"eslint": "^9.39.4"
 	},
 	"overrides": {
 		"nanoid": "^3.3.8"


### PR DESCRIPTION
* Bump undici from 7.18.2 to 7.24.1 (#442)

* Bump minimatch from 3.1.2 to 3.1.5 (#441)

* Bump qs from 6.14.1 to 6.14.2 (#439)
* Bump lodash from 4.17.21 to 4.17.23 (#436)

* Bump eslint from 9.39.2 to 9.39.3 in the development-dependencies group (#440)

* Update deps

* 4.0.1-alpha.1