### PR TITLE
Dependency & Maintenance update (#464)

### DIFF
--- a/.github/workflows/melinda-node-tests-and-webhook.yml
+++ b/.github/workflows/melinda-node-tests-and-webhook.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -32,7 +32,7 @@ jobs:
   license-scan:
     name: License compliance check
     runs-on: ubuntu-latest
-    container: node:22
+    container: node:24
 
     steps:
       - uses: actions/checkout@v6
@@ -43,7 +43,7 @@ jobs:
   njsscan:
     name: Njsscan check
     runs-on: ubuntu-latest
-    container: node:22
+    container: node:24
 
     steps:
     - name: Checkout the code
@@ -92,7 +92,7 @@ jobs:
     name: OpenShift webhook for image builder
     needs: [build-node-versions, njsscan]
     runs-on: ubuntu-latest
-    container: node:22
+    container: node:24
 
     steps:
       - name: Production bib webhook

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
 	"name": "@natlibfi/melinda-rest-api-http",
-	"version": "4.0.3",
+	"version": "4.0.4-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-rest-api-http",
-			"version": "4.0.3",
+			"version": "4.0.4-alpha.1",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record-serializers": "^11.0.2",
+				"@natlibfi/marc-record-serializers": "^11.0.3",
 				"@natlibfi/melinda-backend-commons": "^3.0.5",
 				"@natlibfi/melinda-commons": "^14.0.2",
-				"@natlibfi/melinda-rest-api-commons": "^5.0.6",
-				"@natlibfi/passport-melinda-aleph": "^4.0.0",
+				"@natlibfi/melinda-rest-api-commons": "^5.0.7",
+				"@natlibfi/passport-melinda-aleph": "^4.0.1",
 				"@natlibfi/sru-client": "^7.0.1",
 				"body-parser": "^2.2.2",
 				"esbuild": "^0.28.0",
-				"express": "^4.22.1",
+				"express": "^4.22.2",
 				"http-status": "^2.1.0",
 				"ip-range-check": "^0.2.0",
 				"moment": "^2.30.1",
@@ -27,7 +27,7 @@
 			},
 			"devDependencies": {
 				"cross-env": "^10.1.0",
-				"eslint": "^10.3.0"
+				"eslint": "^10.4.0"
 			},
 			"engines": {
 				"node": ">=22"
@@ -546,9 +546,9 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-			"integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -692,9 +692,9 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.1.tgz",
-			"integrity": "sha512-ENEMr0sMyM/LUViZ/+/SKQq/u9gju8GBKY4Rx+NsQ1JhV69F0/YbURropawG6eZHZJx0IlO7ncYZPJ6DfqWFHQ==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.2.tgz",
+			"integrity": "sha512-4w+YskqHX6IgHXJK6cy7RYJjamuMh/mrBEMLlsQVNJLUU7iv+0RsMBJdBYdyap5krBGVYYKGJwNiJkQy9V4JDA==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.3",
@@ -705,13 +705,13 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-11.0.2.tgz",
-			"integrity": "sha512-kic65Waxmj7N1XZsSM90/5X06TrVcGWZWU9ISEJC9ABHW9EAF70qcaZWnSRBk94MlXcx/RMkHZCVNPCQ/gLfZg==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-11.0.3.tgz",
+			"integrity": "sha512-Gde+TxGcSyj206e3X9ySMmE4mHfm+fEHXUOZ8rKXWzp/Ci/l9AVuLnY0rO0hxf9JZNWxAs4eJP42qgCBqCi7+w==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.1",
-				"@xmldom/xmldom": "^0.9.9",
+				"@natlibfi/marc-record": "^10.0.2",
+				"@xmldom/xmldom": "^0.9.10",
 				"stream-json": "^1.9.1",
 				"xml2js": "^0.6.2",
 				"yargs": "^18.0.0"
@@ -803,16 +803,16 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-5.0.6.tgz",
-			"integrity": "sha512-9zDZxIrmKIYXXmPGha2cGQ7h1gh6YDi5YGglG02McdsdZL2/LKi7OekS5b0WHDzRZcPo0M0gy67kWoyV6ZJYIA==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-5.0.7.tgz",
+			"integrity": "sha512-wzzGClyvhQgjUhEB2ShXZecjowWl9WVJW7UJW+qspZ/dPkyHvnRLBpkvMKXyjjfYd5bX8slFnLggeIQcGeOrOg==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.1",
-				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/marc-record": "^10.0.2",
+				"@natlibfi/marc-record-serializers": "^11.0.3",
 				"@natlibfi/marc-record-validate": "^9.0.0",
-				"@natlibfi/marc-record-validators-melinda": "^12.0.10",
-				"@natlibfi/melinda-backend-commons": "^3.0.4",
+				"@natlibfi/marc-record-validators-melinda": "^12.0.15",
+				"@natlibfi/melinda-backend-commons": "^3.0.5",
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"amqplib": "^0.10.9",
 				"debug": "^4.4.3",
@@ -826,13 +826,13 @@
 			}
 		},
 		"node_modules/@natlibfi/passport-melinda-aleph": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/passport-melinda-aleph/-/passport-melinda-aleph-4.0.0.tgz",
-			"integrity": "sha512-Tzx3ZPHG/9R9lqyqiNVq9sRgsmxAv8my6Fg4P7xMcTOXQr3SB99Or7S19d0hbP/6dFoPF90nADeEAQnwcEXeUw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/passport-melinda-aleph/-/passport-melinda-aleph-4.0.1.tgz",
+			"integrity": "sha512-Uek91eqS7wvVTdjOgQcrtbxMEreZ68KxN7YQueCqhD7ksZxcCfDQ0maKXGd40FJRrHCx98gq0f2VTQCMCHjaag==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/melinda-commons": "^14.0.0",
-				"@xmldom/xmldom": "^0.9.8",
+				"@natlibfi/melinda-commons": "^14.0.2",
+				"@xmldom/xmldom": "^0.9.10",
 				"debug": "^4.4.3",
 				"http-status": "^2.1.0",
 				"passport": "^0.7.0",
@@ -1089,9 +1089,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1620,16 +1620,16 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-			"integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+			"integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
 				"@eslint/config-array": "^0.23.5",
-				"@eslint/config-helpers": "^0.5.5",
+				"@eslint/config-helpers": "^0.6.0",
 				"@eslint/core": "^1.2.1",
 				"@eslint/plugin-kit": "^0.7.1",
 				"@humanfs/node": "^0.16.6",
@@ -1781,14 +1781,14 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+			"integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
+				"body-parser": "~1.20.5",
 				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
 				"cookie": "~0.7.1",
@@ -1807,7 +1807,7 @@
 				"parseurl": "~1.3.3",
 				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
+				"qs": "~6.15.1",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
 				"send": "~0.19.0",
@@ -1866,21 +1866,6 @@
 				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
-		"node_modules/express/node_modules/body-parser/node_modules/qs": {
-			"version": "6.15.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/express/node_modules/debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1916,21 +1901,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
-		},
-		"node_modules/express/node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/express/node_modules/raw-body": {
 			"version": "2.5.3",
@@ -2939,9 +2909,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-rest-api-http.git"
 	},
 	"license": "MIT",
-	"version": "4.0.3",
+	"version": "4.0.4-alpha.1",
 	"main": "dist/index.js",
 	"type": "module",
 	"engines": {
@@ -34,15 +34,15 @@
 		"dev:test": "cross-env DEBUG=@natlibfi/* LOG_LEVEL=debug NODE_ENV=test node --watch --test --experimental-test-coverage --test-reporter=spec './test/*.test.js' './test/**/*.test.js'"
 	},
 	"dependencies": {
-		"@natlibfi/marc-record-serializers": "^11.0.2",
+		"@natlibfi/marc-record-serializers": "^11.0.3",
 		"@natlibfi/melinda-backend-commons": "^3.0.5",
 		"@natlibfi/melinda-commons": "^14.0.2",
-		"@natlibfi/melinda-rest-api-commons": "^5.0.6",
-		"@natlibfi/passport-melinda-aleph": "^4.0.0",
+		"@natlibfi/melinda-rest-api-commons": "^5.0.7",
+		"@natlibfi/passport-melinda-aleph": "^4.0.1",
 		"@natlibfi/sru-client": "^7.0.1",
 		"body-parser": "^2.2.2",
 		"esbuild": "^0.28.0",
-		"express": "^4.22.1",
+		"express": "^4.22.2",
 		"http-status": "^2.1.0",
 		"ip-range-check": "^0.2.0",
 		"moment": "^2.30.1",
@@ -52,7 +52,7 @@
 	},
 	"devDependencies": {
 		"cross-env": "^10.1.0",
-		"eslint": "^10.3.0"
+		"eslint": "^10.4.0"
 	},
 	"overrides": {
 		"nanoid": "^3.3.8"


### PR DESCRIPTION
* Bump qs and express (#463) Updates `qs` from 6.15.1 to 6.15.2
Updates `express` from 4.22.1 to 4.22.2

* Update node-tests-and-webhook

* Update deps

* 4.0.4-alpha.1